### PR TITLE
Null Reference if mesh destroyed

### DIFF
--- a/AlembicImporter/Assets/UTJ/Alembic/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/AlembicImporter/Assets/UTJ/Alembic/Scripts/Exporter/AlembicExporter_impl.cs
@@ -294,6 +294,11 @@ namespace UTJ.Alembic
             public override void Setup(Component c)
             {
                 var target = c as Transform;
+                if (parent == null || target == null)
+				{
+					m_target = null;
+					return;
+				}
                 abcObject = parent.abcObject.NewXform(target.name + " (" + target.GetInstanceID().ToString("X8") + ")", timeSamplingIndex);
                 m_target = target;
             }


### PR DESCRIPTION
Was trying to export some meshes that are destroyed randomly, ran into this null reference error, this was fast fix. Not sure if there are negative side effects by fixing this way ?