### PR TITLE
Uni-42750 macOS: use cmake to run test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,7 +78,7 @@ test:osx:
   stage: test
   script: 
     - cd build
-    - make test
+    - cmake --build . --target test
   dependencies:
   - build:osx
   
@@ -86,7 +86,7 @@ test:windows:
   stage: test
   script: 
     - cd build
-    - make test
+    - cmake --build . --target test
   dependencies:
   - build:windows
   
@@ -94,7 +94,7 @@ test:linux:
   stage: test
   script: 
     - cd build
-    - make test
+    - cmake --build . --target test
   dependencies:
   - build:linux
   


### PR DESCRIPTION
Test job may be on another machine with cmake installed in a different location. 
Use cmake to run test.