### PR TITLE
UNI-50971 make property type public to remove warning

### DIFF
--- a/AlembicImporter/Packages/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/AlembicImporter/Packages/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -283,7 +283,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
     {
         public IntPtr data;
         public int size;
-        aiPropertyType type;
+        public aiPropertyType type;
 
         public aiPropertyData(IntPtr data, int size, aiPropertyType type)
         {


### PR DESCRIPTION
- type is a struct and everything is already internal