### PR TITLE
Uni 55220 run export tests in standalone

### DIFF
--- a/TestProjects/AlembicImporter/Assets/Tests/Runtime/UnitTests/AlembicExportTest.cs
+++ b/TestProjects/AlembicImporter/Assets/Tests/Runtime/UnitTests/AlembicExportTest.cs
@@ -118,9 +118,9 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
 #endif
         }
 
+#if UNITY_EDITOR
         // Helper for the tear-down. This is run from the editor's update loop.
         void DeleteOnNextUpdate () {
-#if UNITY_EDITOR
             EditorApplication.update -= DeleteOnNextUpdate;
             try {
                 Directory.Delete (filePath, recursive : true);
@@ -128,8 +128,8 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             } catch (IOException) {
                 // ignore -- something else must have deleted this.
             }
-#endif
         }
+#endif
 
     }
 
@@ -151,6 +151,9 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
         /// </summary>
         /// <param name="abcPath"></param>
         private void TestAbcImported (string abcPath) {
+            // AssetDatabase is only available in Editor,
+            // make sure it doesn't run in standalone test
+            // otherwise test will fail.
 #if UNITY_EDITOR
             AssetDatabase.Refresh ();
 #endif
@@ -160,6 +163,9 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             Assert.That (string.IsNullOrEmpty (absPath), Is.False);
             Assert.That (File.Exists (absPath));
 
+            // AssetDatabase is only available in Editor,
+            // make sure it doesn't run in standalone test
+            // otherwise test will fail.
 #if UNITY_EDITOR
             // now try loading the asset to see if it imported properly
             var obj = AssetDatabase.LoadMainAssetAtPath (abcPath);

--- a/TestProjects/AlembicImporter/Assets/Tests/Runtime/UnitTests/AlembicExportTest.cs
+++ b/TestProjects/AlembicImporter/Assets/Tests/Runtime/UnitTests/AlembicExportTest.cs
@@ -183,6 +183,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
 #endif
             yield return null;
         }
+
         // Sets a random, temporary filepath for a given Alembic exporter in the scene.
         string SetupExporter (AlembicExporter exporter = null) {
             if (exporter == null) {
@@ -192,6 +193,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             exporter.recorder.settings.OutputPath = GetAssetsAbsolutePath (exportPath);
             return exportPath;
         }
+
         // Begin recording and yield until the recording is done
         IEnumerator RecordAlembic (AlembicExporter exporter = null) {
             if (exporter == null) {
@@ -208,6 +210,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             }
 
         }
+
         // Loads ands runs generic scenes with vanilla recorder settings
         IEnumerator TestScene (string scene) {
             yield return SceneLoader (scene);
@@ -220,6 +223,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return RecordAlembic (exporter);
             TestAbcImported (exportFile);
         }
+
         // One shot export
         [UnityTest]
         public IEnumerator TestOneShotExport () {
@@ -232,21 +236,25 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return null;
             TestAbcImported (exportFile);
         }
+
         // Export Cloth
         [UnityTest]
         public IEnumerator TestClothExport () {
             yield return TestScene ("TestCloth");
         }
+
         //Test Export of multiple, varied assets in a scene
         [UnityTest]
         public IEnumerator TestMultipleExport () {
             yield return TestScene ("TestExport");
         }
+
         //CustomCapturer
         [UnityTest]
         public IEnumerator TestCustomCapturer () {
             yield return TestScene ("TestCustomCapturer");
         }
+
         // GUI  Linear
         [UnityTest]
         public IEnumerator TestGUIUniform () {
@@ -260,6 +268,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return RecordAlembic (exporter);
             TestAbcImported (exportFile);
         }
+
         // GUI  Acyclic
         [UnityTest]
         public IEnumerator TestAcyclic () {
@@ -273,6 +282,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return RecordAlembic (exporter);
             TestAbcImported (exportFile);
         }
+
         // Swap xform test
         [UnityTest]
         public IEnumerator TestXform () {
@@ -286,6 +296,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return null;
             TestAbcImported (exportFile);
         }
+
         // Other file format test
         [UnityTest]
         public IEnumerator TestHDF5 () {
@@ -299,6 +310,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return RecordAlembic (exporter);
             TestAbcImported (exportFile);
         }
+
         // Swap handedness test
         [UnityTest]
         public IEnumerator TestSwapHandedness () {
@@ -312,6 +324,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return RecordAlembic (exporter);
             TestAbcImported (exportFile);
         }
+
         //Small Scale Recording
         [UnityTest]
         public IEnumerator TestScaleFactor () {
@@ -325,6 +338,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return RecordAlembic (exporter);
             TestAbcImported (exportFile);
         }
+
         // Low Frame Rate
         [UnityTest]
         public IEnumerator TestLowFrameRate () {
@@ -339,6 +353,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return RecordAlembic (exporter);
             TestAbcImported (exportFile);
         }
+
         // High Frame Rate
         [UnityTest]
         public IEnumerator TestHighFrameRate () {
@@ -353,6 +368,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
             yield return RecordAlembic (exporter);
             TestAbcImported (exportFile);
         }
+
         // Swap Faces
         [UnityTest]
         public IEnumerator TestSwapFaces () {

--- a/TestProjects/AlembicImporter/Assets/Tests/Runtime/UnitTests/AlembicExportTest.cs
+++ b/TestProjects/AlembicImporter/Assets/Tests/Runtime/UnitTests/AlembicExportTest.cs
@@ -1,15 +1,10 @@
 ﻿using System.Collections;
 using System.IO;
-using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Exporter;
 using UnityEngine.Formats.Alembic.Sdk;
-using UnityEngine.Formats.Alembic.Timeline;
-using UnityEngine.Formats.Alembic.Util;
-using UnityEngine.Playables;
 using UnityEngine.TestTools;
-using UnityEngine.Timeline;
 
 namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
     public class AlembicTestBase {
@@ -386,7 +381,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests {
         [Ignore ("You can't access Alembic Timeline recorder clip settings programatically - so there's functionally no way of customizing the settings via code")]
         [UnityTest]
         public IEnumerator TestCreateAndDelete () {
-            SceneManagement.EditorSceneManager.LoadScene ("TestCreateAndDelete", UnityEngine.SceneManagement.LoadSceneMode.Single);
+            yield return SceneLoader("TestCreateAndDelete");
             yield return new WaitForSeconds (9f);
             // Afaik, there is no programmatical way of manually accessing Alembic recorder clip settings, thus the path has to be set manually
             TestAbcImported ("Assets/UnitTests/RecorderUnitTests/Recorder.abc");


### PR DESCRIPTION
I left the tests so that they can be run in both the editor or standalone, however with `-batchmode` they will only work in standalone. In order to force standalone, the following can be added either to the test class or to individual tests:

```
[UnityPlatform(exclude = new[] { RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor, RuntimePlatform.OSXEditor })]
```

Here are the command line arguments used for running the tests:
/path/to/Unity.exe -batchmode -projectPath path/to/repo/TestProjects/AlembicImporter/ -forgetProjectPath -automated -testResults path/to/repo/TestResults_playmode_AlembicImporter.xml -logFile path/to/repo/editor_playmode_AlembicImporter.log -runTests **-testPlatform StandaloneWindows64**

Note: for the test platform I had to use StandaloneWindows64, the other options are at the bottom of this page: https://docs.unity3d.com/Manual/PlaymodeTestFramework.html