### PR TITLE
fixed windows plugin meta file platform settings

### DIFF
--- a/proto.com.unity.formats.alembic/Runtime/Plugins/x86_64/abci.dll.meta
+++ b/proto.com.unity.formats.alembic/Runtime/Plugins/x86_64/abci.dll.meta
@@ -5,9 +5,23 @@ PluginImporter:
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
   platformData:
+  - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux: 1
+        Exclude Linux64: 0
+        Exclude LinuxUniversal: 0
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 0
   - first:
       '': OSXIntel
     second:
@@ -23,15 +37,16 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: x86_64
         DefaultValueInitialized: true
+        OS: Windows
   - first:
       Facebook: Win
     second:


### PR DESCRIPTION
Corrected platform settings: Editor & Standalone, 64-bit only, .dll is for Windows, .bundle for MacOS, .so is for Linux.