### PR TITLE
turn off default import of point clouds (fixes DCC-303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changes in Alembic for Unity
 
-## [1.0.0] - 2018-10-06
-- Removed preview tag from version
+## [1.0.0-preview.6] - 2018-11-22
+- Apply transform to points renderer by default
+- Don't import point clouds by default
 
 ## [1.0.0-preview.4] - 2018-10-05
 - Added missing Linux dso

--- a/proto.com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicSettings.cs
+++ b/proto.com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicSettings.cs
@@ -127,7 +127,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool importPoints = true;
+        private bool importPoints = false;
         public bool ImportPoints
         {
             get { return importPoints; }


### PR DESCRIPTION
turn off default import of point clouds (fixes DCC-303)
update changlog