### PR TITLE
FTV-28 As a film/tv artist using the Unity Editor, I don't want .abc files copied to StreamingAssets so I don't have data duplication in my project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes in Alembic for Unity
 
+## [1.0.0-preview.8] - 2018-12-19
+### Changes
+- Alembic files are No longer copied to the StreamingAssets folder
+
+### Known Issues
+- If you rename the prefab once instantiated, all scene references are lost (move works)
+
 ## [1.0.0-preview.7] - 2018-11-28
 ### Changes
 - Fixed Windows plugin platform settings

--- a/proto.com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/proto.com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -26,19 +26,6 @@ namespace UnityEditor.Formats.Alembic.Importer
             var streamingAssetPath = AlembicImporter.MakeShortAssetPath(assetPath);
             AlembicStream.DisconnectStreamsWithPath(streamingAssetPath);
 
-            try
-            {
-                var fullStreamingAssetPath = Application.streamingAssetsPath + streamingAssetPath;
-                File.SetAttributes(fullStreamingAssetPath, FileAttributes.Normal);
-                File.Delete(fullStreamingAssetPath);
-                File.SetAttributes(fullStreamingAssetPath + ".meta", FileAttributes.Normal);
-                File.Delete(fullStreamingAssetPath + ".meta");
-            }
-            catch (System.Exception e)
-            {
-                Debug.LogWarning(e);
-            }
-
             return AssetDeleteResult.DidNotDelete;
         }
 
@@ -55,38 +42,10 @@ namespace UnityEditor.Formats.Alembic.Importer
             var streamSrcPath = AlembicImporter.MakeShortAssetPath(from);
             AlembicStream.DisconnectStreamsWithPath(streamSrcPath);
             AlembicStream.RemapStreamsWithPath(streamSrcPath,streamDstPath);
-
-            var dstPath = Application.streamingAssetsPath + streamDstPath;
-            var srcPath = Application.streamingAssetsPath + streamSrcPath;
-
-            try
-            {
-                var directoryPath = Path.GetDirectoryName(dstPath);
-                if (File.Exists(dstPath))
-                {
-                    File.SetAttributes(dstPath + ".meta", FileAttributes.Normal);
-                    File.Delete(dstPath);
-                }
-                else if (!Directory.Exists(directoryPath))
-                {
-                    Directory.CreateDirectory(directoryPath);
-                }
-                if (File.Exists(dstPath))
-                    File.SetAttributes(dstPath, FileAttributes.Normal);
-                File.Move(srcPath, dstPath);
-                if (File.Exists(dstPath + ".meta"))
-                {
-                    File.SetAttributes(dstPath + ".meta", FileAttributes.Normal);
-                    File.Move(srcPath + ".meta", dstPath + ".meta");
-                }
-
-                AssetDatabase.Refresh(ImportAssetOptions.Default);
-                AlembicStream.ReconnectStreamsWithPath(streamDstPath);
-            }
-            catch (System.Exception e)
-            {
-                Debug.LogWarning(e);
-            }
+            
+            AssetDatabase.Refresh(ImportAssetOptions.Default);
+    		AlembicStream.ReconnectStreamsWithPath(streamDstPath);
+ 
             return AssetMoveResult.DidNotMove;
         } 
     }
@@ -173,15 +132,8 @@ namespace UnityEditor.Formats.Alembic.Importer
 
             var shortAssetPath = MakeShortAssetPath(ctx.assetPath);
             AlembicStream.DisconnectStreamsWithPath(shortAssetPath);
-            var sourcePath = Application.dataPath + shortAssetPath;
-            var destPath = Application.streamingAssetsPath + shortAssetPath;
-            var directoryPath = Path.GetDirectoryName(destPath);
-            if (!Directory.Exists(directoryPath))
-                Directory.CreateDirectory(directoryPath);
-            if (File.Exists(destPath))
-                File.SetAttributes(destPath, FileAttributes.Normal);
-            File.Copy(sourcePath, destPath ,true);
 
+            var destPath = AlembicStream.basePath + shortAssetPath;
             var fileName = Path.GetFileNameWithoutExtension(destPath);
             var go = new GameObject(fileName);
             

--- a/proto.com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/proto.com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -11,10 +11,14 @@ namespace UnityEngine.Formats.Alembic.Importer
     internal sealed class AlembicStream : IDisposable
     {
         static List<AlembicStream> s_streams = new List<AlembicStream>();
+        public static string basePath
+        {
+            get { return Application.dataPath; }
+        }
 
         public static void DisconnectStreamsWithPath(string path)
         {
-            var fullPath = Application.streamingAssetsPath + path;
+            var fullPath = basePath + path;
             aiContext.DestroyByPath(fullPath);
             s_streams.ForEach(s => {
                 if (s.m_streamDesc.PathToAbc == path)
@@ -139,7 +143,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             m_config.importTrianglePolygon = settings.ImportTrianglePolygon;
 
             m_context.SetConfig(ref m_config);
-            m_loaded = m_context.Load(Application.streamingAssetsPath + m_streamDesc.PathToAbc);
+            m_loaded = m_context.Load(basePath + m_streamDesc.PathToAbc);
 
             if (m_loaded)
             {
@@ -148,7 +152,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             }
             else
             {
-                Debug.LogError("failed to load alembic at " + Application.streamingAssetsPath + m_streamDesc.PathToAbc);
+                Debug.LogError("failed to load alembic at " + basePath + m_streamDesc.PathToAbc);
             }
         }
 


### PR DESCRIPTION
Tested that files can be moved around and overwritten when the Alembic prefab is instanced.