### PR TITLE
fixed DCC-833 - dll not found

### DIFF
--- a/cmake/AddPlugin.cmake
+++ b/cmake/AddPlugin.cmake
@@ -79,6 +79,7 @@ function(add_plugin name)
         # Add the ALIAS so that the tests don't have to think about this mess.
         add_library(${name} MODULE ${arg_SOURCES})
         add_library(${name}_test_lib ALIAS ${name})
+        set_target_properties(${name} PROPERTIES PREFIX "")
     endif()
 
     # Hide symbols so they can be stripped.

--- a/proto.com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/proto.com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -294,14 +294,14 @@ namespace UnityEngine.Formats.Alembic.Sdk
     }
 
     internal static class Abci {
-#if UNITY_STANDALONE
-        internal const string Lib = "abci";
-#elif UNITY_EDITOR_OSX
+#if UNITY_EDITOR_OSX
         internal const string Lib = "Packages/com.unity.formats.alembic/Runtime/Plugins/x86_64/abci.bundle/Contents/MacOS/abci";
 #elif UNITY_EDITOR_LINUX
-        internal const string Lib = "Packages/com.unity.formats.alembic/Runtime/Plugins/x86_64/libabci.so";
+        internal const string Lib = "Packages/com.unity.formats.alembic/Runtime/Plugins/x86_64/abci.so";
 #elif UNITY_EDITOR_WIN
         internal const string Lib = "Packages/com.unity.formats.alembic/Runtime/Plugins/x86_64/abci.dll";
+#elif UNITY_STANDALONE
+        internal const string Lib = "abci";
 #endif
     }
 


### PR DESCRIPTION
reordered paths to put standalone last, otherwise it's picked first
renamed linux dso to abci.so instead of libabci.so for consistency