### PR TITLE
Implement GatherProperties so the Alembic Clip does not change the sc…

### DIFF
--- a/proto.com.unity.formats.alembic/Runtime/Scripts/Timeline/AlembicShotAsset.cs
+++ b/proto.com.unity.formats.alembic/Runtime/Scripts/Timeline/AlembicShotAsset.cs
@@ -7,7 +7,7 @@ using UnityEngine.Timeline;
 namespace UnityEngine.Formats.Alembic.Timeline
 {
     [System.ComponentModel.DisplayName("Alembic Shot")]
-    internal class AlembicShotAsset : PlayableAsset, ITimelineClipAsset
+    internal class AlembicShotAsset : PlayableAsset, ITimelineClipAsset, IPropertyPreview
     {
         AlembicStreamPlayer m_stream;
 
@@ -48,5 +48,13 @@ namespace UnityEngine.Formats.Alembic.Timeline
             }
         }
 
+        public void GatherProperties(PlayableDirector director, IPropertyCollector driver)
+        {
+            var streamComponent = streamPlayer.Resolve(director);
+            if (streamComponent != null)
+            {
+                driver.AddFromName<AlembicStreamPlayer>(streamComponent.gameObject,"currentTime");
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently whenever a timeline is driving an AlembicStreamPlayer, it is constantly changing the scene asset. 
After this change, the time is registered with the timeline as a "Driven Property"( the scene changes are not persistent, once the timeline is stopped or out of focus).