### PR TITLE
Remove linux32

### DIFF
--- a/TestProjects/AlembicImporter/Packages/manifest.json
+++ b/TestProjects/AlembicImporter/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "com.unity.formats.alembic": "file:../../../build/install/automation/packages/alembic",
-    "com.unity.formats.alembic.tests": "file:../../../build/install/automation/packages/alembic-tests",
     "com.unity.package-manager-ui": "2.0.3",
     "com.unity.package-validation-suite": "0.4.0-preview.12",
     "com.unity.timeline": "1.0.0",
@@ -37,6 +36,6 @@
     "com.unity.modules.xr": "1.0.0"
   },
   "testables": [
-    "com.unity.formats.alembic.tests"
+    "com.unity.formats.alembic"
   ]
 }

--- a/proto.com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/proto.com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -761,8 +761,12 @@ namespace UnityEngine.Formats.Alembic.Util
 #else
                 method.Invoke(null, new object[] { BuildTarget.StandaloneOSXUniversal, 0, 0 });
 #endif
-                method.Invoke(null, new object[] { BuildTarget.StandaloneLinux, 0, 0 });
                 method.Invoke(null, new object[] { BuildTarget.StandaloneLinux64, 0, 0 });
+// Deprecated in 2019.2
+#if UNITY_2019_2_OR_NEWER
+#else
+                method.Invoke(null, new object[] { BuildTarget.StandaloneLinux, 0, 0 });
+#endif
             }
         }
 #endif

--- a/proto.com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.asmdef
+++ b/proto.com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.asmdef
@@ -4,7 +4,6 @@
   "optionalUnityReferences": [],
   "includePlatforms": [
     "Editor",
-    "LinuxStandalone64",
     "macOSStandalone",
     "WindowsStandalone64"
   ],

--- a/proto.com.unity.formats.alembic/Tests/.tests.json
+++ b/proto.com.unity.formats.alembic/Tests/.tests.json
@@ -1,3 +1,0 @@
-{
-	"createSeparatePackage": true
-}

--- a/proto.com.unity.formats.alembic/Tests/Runtime/Unity.Formats.Alembic.Tests.asmdef
+++ b/proto.com.unity.formats.alembic/Tests/Runtime/Unity.Formats.Alembic.Tests.asmdef
@@ -9,7 +9,6 @@
     ],
     "includePlatforms": [
         "Editor",
-        "LinuxStandalone64",
         "macOSStandalone",
         "WindowsStandalone64"
     ],

--- a/proto.com.unity.formats.alembic/package.json.in
+++ b/proto.com.unity.formats.alembic/package.json.in
@@ -21,5 +21,5 @@
     }, 
     "unity": "2018.3",
     "unityRelease": "4f1",
-    "version": "@PACKAGE_VERSION@"
+    "version": "1.0.2"
 }

--- a/repack.sh
+++ b/repack.sh
@@ -11,6 +11,4 @@ mv automation ../
 cd ../automation/packages
 tar -xzvf `find . -iname '*alembic-*.tgz'`
 mv package alembic
-tar -xzvf `find . -iname '*alembic.*.tgz'`
-mv package alembic-tests
 popd


### PR DESCRIPTION
This PR removes the usage of BuildTarget.StandaloneLinux for 2019.2+ since it's being obsoleted.
Small side cleanup, removed all linux mentions form asmdef-s (should have been done in the initial commit since it's not compatible with linux today.)