### PR TITLE
Windows file locks ftv-142

### DIFF
--- a/Source/abci/Importer/aiContext.cpp
+++ b/Source/abci/Importer/aiContext.cpp
@@ -61,6 +61,8 @@ private:
             NULL);
         if (_handle == INVALID_HANDLE_VALUE)
         {
+            auto errorMsg = GetLastErrorAsString();
+            std::cerr << "Alembic cannot open:" << name <<":"<<errorMsg << std::endl;
             return nullptr;
         }
 
@@ -68,7 +70,7 @@ private:
 
         if (nHandle == -1)
         {
-           ::CloseHandle(_handle);
+            ::CloseHandle(_handle);
             return nullptr;
         }
 
@@ -88,8 +90,33 @@ public:
     {
         if (_handle != INVALID_HANDLE_VALUE)
         {
+            auto errorMsg = GetLastErrorAsString();
+            std::cerr << "Alembic cannot close HANDLE:" << errorMsg << std::endl;
             ::CloseHandle(_handle);
         }
+    }
+
+private:
+    std::string GetLastErrorAsString()
+    {
+        DWORD errorMessageID = ::GetLastError();
+        if (errorMessageID == 0)
+            return std::string();
+
+        LPSTR messageBuffer = nullptr;
+        size_t size = 
+            FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                           NULL, 
+                           errorMessageID, 
+                           MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
+                           (LPSTR)&messageBuffer, 
+                           0, 
+                           NULL);
+
+        std::string message(messageBuffer, size);
+        LocalFree(messageBuffer);
+
+        return message;
     }
 };
 #endif

--- a/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
@@ -77,6 +77,8 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             {
                 File.Delete(file);
             }
+            
+            deleteFileList.Clear();
         }
     }
 }


### PR DESCRIPTION
This PR changes the windows implementation for file access.
On windows there are certain apps (P4) that are unable to update the ABC assets when they are opened in Unity because of the OS locks. This implementation uses windows APIs to open files without locks.