### PR TITLE
Standalone player FTV-92

### DIFF
--- a/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEditor.Callbacks;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.Formats.Alembic.Importer;
+using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
+
+namespace UnityEditor.Formats.Alembic.Importer
+{
+    public static class AlembicBuildPostProcess
+    {
+        internal static readonly List<KeyValuePair<string,string>> FilesToCopy = new List<KeyValuePair<string,string>>();
+        [PostProcessBuild]
+        public static void OnPostProcessBuild(BuildTarget target, string pathToBuiltProject)
+        {
+            if (target != BuildTarget.StandaloneOSX && target != BuildTarget.StandaloneWindows64)
+            {
+                return;
+            }
+
+            foreach (var files in FilesToCopy)
+            {
+                var dir = Path.GetDirectoryName(files.Value);
+                if (dir != null && !Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                File.Copy(files.Key,files.Value);
+            }
+            
+            FilesToCopy.Clear();
+        }
+    }
+
+    class AlembicProcessScene : IProcessSceneWithReport
+    {
+        public int callbackOrder
+        {
+            get { return 9999;}  
+        }
+
+        public void OnProcessScene(Scene scene, BuildReport report)
+        {
+            if (report == null || 
+                (report.summary.platform != BuildTarget.StandaloneOSX &&
+                report.summary.platform != BuildTarget.StandaloneWindows64))
+            {
+                return;
+                
+            }
+            var activeScene = SceneManager.GetActiveScene();
+            SceneManager.SetActiveScene(scene);
+            var players = Object.FindObjectsOfType<AlembicStreamPlayer>();
+            var pathToStreamingAssets = GetStreamingAssetsPath(report.summary);
+            foreach (var p in players)
+            {
+                ProcessAlembicStreamPlayerAssets(p, pathToStreamingAssets, report.summary.outputPath);
+            }
+            SceneManager.SetActiveScene(activeScene);
+        }
+
+        static void ProcessAlembicStreamPlayerAssets(AlembicStreamPlayer streamPlayer, string streamingAssetsPath, string basePath)
+        {
+            streamPlayer.StreamDescriptor = Object.Instantiate(streamPlayer.StreamDescriptor);// make a copy
+            var srcPath = streamPlayer.StreamDescriptor.PathToAbc;
+            var fileName = Path.GetFileName(srcPath);
+            var dstPath = Path.Combine(streamingAssetsPath, fileName);
+            AlembicBuildPostProcess.FilesToCopy.Add(new KeyValuePair<string, string>(srcPath,dstPath));
+
+            streamPlayer.StreamDescriptor.PathToAbc = GetAbsolutePath(dstPath, basePath);
+        }
+
+        static string GetStreamingAssetsPath(BuildSummary summary)
+        {
+            switch (summary.platform)
+            {
+                case BuildTarget.StandaloneOSX:
+                    return Path.Combine(summary.outputPath, "Contents/Resources/Data/StreamingAsset");
+                case BuildTarget.StandaloneWindows64:
+                    var name = Path.GetDirectoryName(summary.outputPath);
+                    name = Path.Combine(name, "_Data/StreamingAssets");
+                    return Path.Combine(summary.outputPath, name);
+                default:
+                    throw new NotImplementedException();   
+            }
+        }
+
+        static string GetAbsolutePath(string fullPath, string basePath)
+        {
+            var fullPathUri = new Uri(fullPath, UriKind.Absolute);
+            var basePathUri = new Uri(basePath, UriKind.Absolute);
+            return basePathUri.MakeRelativeUri(fullPathUri).ToString();
+        }
+    }
+}

--- a/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
@@ -83,7 +83,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             switch (summary.platform)
             {
                 case BuildTarget.StandaloneOSX:
-                    return Path.Combine(summary.outputPath, "Contents/Resources/Data/StreamingAsset");
+                    return Path.Combine(summary.outputPath, "Contents/Resources/Data/StreamingAssets");
                 case BuildTarget.StandaloneWindows64:
                     var name = Path.ChangeExtension(summary.outputPath, null);
                     return name+"_Data/StreamingAssets";

--- a/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs.meta
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3cd7be4666f064b7ba04dae380484d24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
@@ -12,7 +12,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             get
             {
 #if UNITY_STANDALONE
-                return Path.Combine(Application.streamingAssetsPath, pathToAbc);
+                return System.IO.Path.Combine(Application.streamingAssetsPath, pathToAbc);
 #else
                 return pathToAbc;
 #endif

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
@@ -8,7 +8,15 @@ namespace UnityEngine.Formats.Alembic.Importer
         private string pathToAbc;
         public string PathToAbc
         {
-            get { return pathToAbc; }
+            // For standalone builds, the path should be relative to the StreamingAssets
+            get
+            {
+#if UNITY_STANDALONE
+                return Path.Combine(Application.streamingAssetsPath, pathToAbc);
+#else
+                return pathToAbc;
+#endif
+            }
             set { pathToAbc = value; }
         }
 


### PR DESCRIPTION
This branch allows users to create standalone players with Alembic that are also redistributable.
To allow this, the alembics are copied into the streaming assets of the player build and all paths are redirected to them.
To eliminate potential name clashes, these files are copied under a hashed name. (hash is dependent on path/name in the project)