### PR TITLE
Switch upm-ci from the dev to the officially released version.

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -45,8 +45,7 @@ pack:
     image: package-ci/win10:stable
     flavor: m1.large
   commands:
-    - git clone --branch dev --single-branch git@gitlab.cds.internal.unity3d.com:upm-packages/project-templates/upm-template-utils.git upm-ci-utils
-    - npm install upm-ci-utils/ -g
+    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack --package-path com.unity.formats.alembic
   artifacts:
    packages:
@@ -68,8 +67,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    - git clone --branch dev --single-branch git@gitlab.cds.internal.unity3d.com:upm-packages/project-templates/upm-template-utils.git upm-ci-utils
-    - npm install upm-ci-utils/ -g
+    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm 
     - upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic
   artifacts:
     logs.zip:


### PR DESCRIPTION
Switch to the proper channel for UPM-CI, the package published on npm.