### PR TITLE
Switch to relative paths.

### DIFF
--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -24,7 +24,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             if (Path.GetExtension(assetPath.ToLower()) != ".abc")
                 return AssetDeleteResult.DidNotDelete;
 
-            AlembicStream.DisconnectStreamsWithPath(Path.GetFullPath(assetPath));
+            AlembicStream.DisconnectStreamsWithPath(assetPath);
 
             return AssetDeleteResult.DidNotDelete;
         }
@@ -38,19 +38,18 @@ namespace UnityEditor.Formats.Alembic.Importer
 
             if (Path.GetExtension(from.ToLower()) != ".abc")
                 return AssetMoveResult.DidNotMove;
-            var streamDstPath = Path.GetFullPath(to);
-            var streamSrcPath = Path.GetFullPath(from);
-            AlembicStream.DisconnectStreamsWithPath(streamSrcPath);
-            AlembicStream.RemapStreamsWithPath(streamSrcPath,streamDstPath);
+
+            AlembicStream.DisconnectStreamsWithPath(from);
+            AlembicStream.RemapStreamsWithPath(from,to);
             
             AssetDatabase.Refresh(ImportAssetOptions.Default);
-    		AlembicStream.ReconnectStreamsWithPath(streamDstPath);
+    		AlembicStream.ReconnectStreamsWithPath(to);
  
             return AssetMoveResult.DidNotMove;
         } 
     }
 
-    [ScriptedImporter(3, "abc")]
+    [ScriptedImporter(4, "abc")]
     internal class AlembicImporter : ScriptedImporter
     {
         [SerializeField]
@@ -125,15 +124,15 @@ namespace UnityEditor.Formats.Alembic.Importer
                 return;
             }
             
-            var fullPath = Path.GetFullPath(ctx.assetPath);
-            AlembicStream.DisconnectStreamsWithPath(fullPath);
+            var path = ctx.assetPath;
+            AlembicStream.DisconnectStreamsWithPath(path);
 
-            var fileName = Path.GetFileNameWithoutExtension(fullPath);
+            var fileName = Path.GetFileNameWithoutExtension(path);
             var go = new GameObject(fileName);
             
             var streamDescriptor = ScriptableObject.CreateInstance<AlembicStreamDescriptor>();
             streamDescriptor.name = go.name + "_ABCDesc";
-            streamDescriptor.PathToAbc = fullPath;
+            streamDescriptor.PathToAbc = path;
             streamDescriptor.Settings = StreamSettings;
 
             using (var abcStream = new AlembicStream(go, streamDescriptor))
@@ -158,7 +157,7 @@ namespace UnityEditor.Formats.Alembic.Importer
                 subassets.Add(streamDescriptor.name, streamDescriptor);
                 GenerateSubAssets(subassets, abcStream.abcTreeRoot, streamDescriptor);
 
-                AlembicStream.ReconnectStreamsWithPath(fullPath);
+                AlembicStream.ReconnectStreamsWithPath(path);
 
 #if UNITY_2017_3_OR_NEWER
                 ctx.AddObjectToAsset(go.name, go);

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using UnityEngine;
 
@@ -313,10 +314,20 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public static bool ToBool(aiContext v) { return v; }
 
         public static aiContext Create(int uid) { return NativeMethods.aiContextCreate(uid); }
-        public static void DestroyByPath(string path) { NativeMethods.aiClearContextsWithPath(path); }
+
+        public static void DestroyByPath(string path)
+        {
+            var fullPath = Path.GetFullPath(path);
+            NativeMethods.aiClearContextsWithPath(fullPath);
+        }
 
         public void Destroy() { NativeMethods.aiContextDestroy(self); self = IntPtr.Zero; }
-        public bool Load(string path) { return NativeMethods.aiContextLoad(self, path); }
+
+        public bool Load(string path)
+        {
+            var fullPath = Path.GetFullPath(path);
+            return NativeMethods.aiContextLoad(self, fullPath);
+        }
         internal void SetConfig(ref aiConfig conf) { NativeMethods.aiContextSetConfig(self, ref conf); }
         public void UpdateSamples(double time) { NativeMethods.aiContextUpdateSamples(self, time); }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
@@ -11,10 +11,10 @@ namespace UnityEngine.Formats.Alembic.Importer
             // For standalone builds, the path should be relative to the StreamingAssets
             get
             {
-#if UNITY_STANDALONE
-                return System.IO.Path.Combine(Application.streamingAssetsPath, pathToAbc);
-#else
+#if UNITY_EDITOR
                 return pathToAbc;
+#else
+                return System.IO.Path.Combine(Application.streamingAssetsPath, pathToAbc);
 #endif
             }
             set { pathToAbc = value; }


### PR DESCRIPTION
Since alembic native needs an absolute path, this is re-resolved every time the ABC is loaded.