### PR TITLE
Add support for  hdrp standard shaders with alembic velocity

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changes in Alembic for Unity
+## [1.0.6] - 2019-07-23
+### Changes
+- Fix for HDRP 7 shipped materials
+
 ## [1.0.5] - 2019-05-10
 ### Changes
 - Fixed regression introduced in 1.0.4 where old Alembic scene instances would lose prefab connection. New scene instances made with 1.0.4 are unfortunately unrecoverable

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -311,7 +311,7 @@ namespace UnityEngine.Formats.Alembic.Importer
                     if (split.uv1.Count > 0)
                         split.mesh.SetUVs(1, split.uv1.List);
                     if (split.velocities.Count > 0)
-#if UNITY_2019_3_OR_NEWER
+#if UNITY_2019_2_OR_NEWER
                         split.mesh.SetUVs(5, split.velocities.List);
                     #else
                         split.mesh.SetUVs(3, split.velocities.List);

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -311,7 +311,7 @@ namespace UnityEngine.Formats.Alembic.Importer
                     if (split.uv1.Count > 0)
                         split.mesh.SetUVs(1, split.uv1.List);
                     if (split.velocities.Count > 0)
-                        split.mesh.SetUVs(3, split.velocities.List);
+                        split.mesh.SetUVs(5, split.velocities.List);
                     if (split.colors.Count > 0)
                         split.mesh.SetColors(split.colors.List);
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -311,7 +311,11 @@ namespace UnityEngine.Formats.Alembic.Importer
                     if (split.uv1.Count > 0)
                         split.mesh.SetUVs(1, split.uv1.List);
                     if (split.velocities.Count > 0)
+#if UNITY_2019_3_OR_NEWER
                         split.mesh.SetUVs(5, split.velocities.List);
+                    #else
+                        split.mesh.SetUVs(3, split.velocities.List);
+#endif
                     if (split.colors.Count > 0)
                         split.mesh.SetColors(split.colors.List);
 

--- a/com.unity.formats.alembic/Runtime/Shaders/StandardRoughness.shader
+++ b/com.unity.formats.alembic/Runtime/Shaders/StandardRoughness.shader
@@ -53,11 +53,11 @@ Shader "Alembic/Standard (Roughness setup)"
         Tags { "RenderType"="Opaque" "PerformanceChecks"="False" }
 
         UsePass "Hidden/Alembic/MotionVectors/MOTIONVECTORS"
-        UsePass "Standard (Roughness setup)/FORWARD"
-        UsePass "Standard (Roughness setup)/FORWARD_DELTA"
-        UsePass "Standard (Roughness setup)/SHADOWCASTER"
-        UsePass "Standard (Roughness setup)/DEFERRED"
-        UsePass "Standard (Roughness setup)/META"
+        UsePass "Autodesk Interactive/FORWARD"
+        UsePass "Autodesk Interactive/FORWARD_DELTA"
+        UsePass "Autodesk Interactive/SHADOWCASTER"
+        UsePass "Autodesk Interactive/DEFERRED"
+        UsePass "Autodesk Interactive/META"
     }
 
     CustomEditor "StandardRoughnessShaderGUI"

--- a/com.unity.formats.alembic/Runtime/Shaders/StandardRoughness.shader
+++ b/com.unity.formats.alembic/Runtime/Shaders/StandardRoughness.shader
@@ -59,6 +59,4 @@ Shader "Alembic/Standard (Roughness setup)"
         UsePass "Autodesk Interactive/DEFERRED"
         UsePass "Autodesk Interactive/META"
     }
-
-    CustomEditor "StandardRoughnessShaderGUI"
 }

--- a/package.json.in
+++ b/package.json.in
@@ -21,5 +21,5 @@
     }, 
     "unity": "2018.3",
     "unityRelease": "4f1",
-    "version": "1.0.5"
+    "version": "1.0.6"
 }


### PR DESCRIPTION
Send the alembic vertex velocity information using the texcoord5 to be compatible with changes to support velocity in the standard hdrp shaders.

See the following branch https://github.com/Unity-Technologies/ScriptableRenderPipeline/tree/hdrp/additional_velocity_change_for_alembic