### PR TITLE
Ftv 167 GameObject rename

### DIFF
--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -54,6 +54,8 @@ namespace UnityEditor.Formats.Alembic.Importer
     {
         [SerializeField]
         private string rootGameObjectId;
+        [SerializeField]
+        private string rootGameObjectName;
 
         [SerializeField]
         private AlembicStreamSettings streamSettings = new AlembicStreamSettings();
@@ -131,7 +133,13 @@ namespace UnityEditor.Formats.Alembic.Importer
             AlembicStream.DisconnectStreamsWithPath(path);
 
             var fileName = Path.GetFileNameWithoutExtension(path);
-            var go = new GameObject(fileName);
+            
+            if (string.IsNullOrEmpty(rootGameObjectName))
+            {
+                rootGameObjectName = fileName;
+                EditorUtility.SetDirty(this);
+            }
+            var go = new GameObject(rootGameObjectName);
 
             var streamDescriptor = ScriptableObject.CreateInstance<AlembicStreamDescriptor>();
             streamDescriptor.name = go.name + "_ABCDesc";

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -39,6 +39,26 @@ namespace UnityEditor.Formats.Alembic.Importer
             if (Path.GetExtension(from.ToLower()) != ".abc")
                 return AssetMoveResult.DidNotMove;
 
+            var importer = AssetImporter.GetAtPath(from) as AlembicImporter;
+            if (importer != null)
+            {
+                var so =new SerializedObject(importer);
+                var prop = so.FindProperty("rootGameObjectName");
+                if (prop != null && string.IsNullOrEmpty(prop.stringValue))
+                {
+                    prop.stringValue = Path.GetFileNameWithoutExtension(from);
+                    so.ApplyModifiedPropertiesWithoutUndo();
+                }
+                
+                prop = so.FindProperty("rootGameObjectId");
+                if (prop != null && string.IsNullOrEmpty(prop.stringValue))
+                {
+                    prop.stringValue = Path.GetFileNameWithoutExtension(from);
+                    so.ApplyModifiedPropertiesWithoutUndo();
+                }
+                AssetDatabase.WriteImportSettingsIfDirty(from);
+            }
+
             AlembicStream.DisconnectStreamsWithPath(from);
             AlembicStream.RemapStreamsWithPath(from, to);
 
@@ -49,14 +69,15 @@ namespace UnityEditor.Formats.Alembic.Importer
         }
     }
 
-    [ScriptedImporter(5, "abc")]
+    [ScriptedImporter(6, "abc")]
     internal class AlembicImporter : ScriptedImporter
     {
         [SerializeField]
+#pragma warning disable 0649
         private string rootGameObjectId;
         [SerializeField]
         private string rootGameObjectName;
-
+#pragma warning restore 0649
         [SerializeField]
         private AlembicStreamSettings streamSettings = new AlembicStreamSettings();
         public AlembicStreamSettings StreamSettings
@@ -133,13 +154,13 @@ namespace UnityEditor.Formats.Alembic.Importer
             AlembicStream.DisconnectStreamsWithPath(path);
 
             var fileName = Path.GetFileNameWithoutExtension(path);
+            var previousGoName = fileName;
             
-            if (string.IsNullOrEmpty(rootGameObjectName))
+            if (!string.IsNullOrEmpty(rootGameObjectName))
             {
-                rootGameObjectName = fileName;
-                EditorUtility.SetDirty(this);
+                previousGoName = rootGameObjectName;
             }
-            var go = new GameObject(rootGameObjectName);
+            var go = new GameObject(previousGoName);
 
             var streamDescriptor = ScriptableObject.CreateInstance<AlembicStreamDescriptor>();
             streamDescriptor.name = go.name + "_ABCDesc";
@@ -170,18 +191,14 @@ namespace UnityEditor.Formats.Alembic.Importer
 
                 AlembicStream.ReconnectStreamsWithPath(path);
 
-                if (string.IsNullOrEmpty(rootGameObjectId))
+                var prevIdName = fileName;
+                if (!string.IsNullOrEmpty(rootGameObjectId))
                 {
-                    rootGameObjectId = fileName;
-                    EditorUtility.SetDirty(this);
+                    prevIdName = rootGameObjectId;
                 }
-
-#if UNITY_2017_3_OR_NEWER
-                ctx.AddObjectToAsset(rootGameObjectId, go);
+                
+                ctx.AddObjectToAsset(prevIdName, go);
                 ctx.SetMainObject(go);
-#else
-                ctx.SetMainAsset(rootGameObjectId, go);
-#endif
             }
 
             firstImport = false;

--- a/com.unity.formats.alembic/Tests/Editor/AssetRenameTests.cs
+++ b/com.unity.formats.alembic/Tests/Editor/AssetRenameTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Formats.Alembic.Importer;
+
+namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
+{
+    public class AssetRenameTests
+    {
+        readonly List<string> deleteFileList = new List<string>();
+        const string copiedAbcFile = "Assets/abc.abc";
+        GameObject go;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var srcDummyFile = AssetDatabase.FindAssets("Dummy").Select(AssetDatabase.GUIDToAssetPath).SelectMany(AssetDatabase.LoadAllAssetsAtPath).OfType<AlembicStreamPlayer>().First().StreamDescriptor.PathToAbc;
+            File.Copy(srcDummyFile,copiedAbcFile, true);
+            AssetDatabase.Refresh();
+            var asset = AssetDatabase.LoadMainAssetAtPath(copiedAbcFile);
+            go = PrefabUtility.InstantiatePrefab(asset) as GameObject;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var file in deleteFileList)
+            {
+                File.Delete(file);
+            }
+
+            deleteFileList.Clear();
+        }
+
+        [Test]
+        public void TestRenameDoesNotRenameInstances()
+        {
+            Assert.AreEqual("abc",go.name);
+            var ret = AssetDatabase.RenameAsset(copiedAbcFile,"new.abc");
+            AssetDatabase.Refresh();
+            Assert.AreEqual("abc",go.name);
+            Assert.IsEmpty(ret);
+            deleteFileList.Add("Assets/new.abc");
+        }
+    }
+}

--- a/com.unity.formats.alembic/Tests/Editor/AssetRenameTests.cs
+++ b/com.unity.formats.alembic/Tests/Editor/AssetRenameTests.cs
@@ -29,7 +29,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         {
             foreach (var file in deleteFileList)
             {
-                File.Delete(file);
+                AssetDatabase.DeleteAsset(file);
             }
 
             deleteFileList.Clear();

--- a/com.unity.formats.alembic/Tests/Editor/AssetRenameTests.cs.meta
+++ b/com.unity.formats.alembic/Tests/Editor/AssetRenameTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1a76f83b35474ba184b5a530cf9dec7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is another bug related to the way prefab references are being stored.
The root gameObject name needs to be file independent. This fix sets the name once and reuses it every time.