### PR TITLE
Ftv 267 hdrp410 material

### DIFF
--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -311,7 +311,14 @@ namespace UnityEngine.Formats.Alembic.Importer
                     if (split.uv1.Count > 0)
                         split.mesh.SetUVs(1, split.uv1.List);
                     if (split.velocities.Count > 0)
+                    {
+#if UNITY_2019_2_OR_NEWER
+                        split.mesh.SetUVs(5, split.velocities.List);
+#else
                         split.mesh.SetUVs(3, split.velocities.List);
+#endif
+                    }
+
                     if (split.colors.Count > 0)
                         split.mesh.SetColors(split.colors.List);
 

--- a/com.unity.formats.alembic/Runtime/Shaders/HD/LitAlembic.shader
+++ b/com.unity.formats.alembic/Runtime/Shaders/HD/LitAlembic.shader
@@ -323,22 +323,23 @@
         Tags{ "RenderPipeline"="HDRenderPipeline" "RenderType" = "HDLitShader" }
 
         // Default to normal HD Render Pipeline Lit Passes.
-        UsePass "HDRenderPipeline/Lit/SCENESELECTIONPASS"
-        UsePass "HDRenderPipeline/Lit/GBUFFER"
-        UsePass "HDRenderPipeline/Lit/META"
-        UsePass "HDRenderPipeline/Lit/SHADOWCASTER"
-        UsePass "HDRenderPipeline/Lit/DEPTHONLY"
-        UsePass "HDRenderPipeline/Lit/DISTORTION"
-        UsePass "HDRenderPipeline/Lit/TRANSPARENTDEPTHPREPASS"
-        UsePass "HDRenderPipeline/Lit/TRANSPARENTBACKFACE"
-        UsePass "HDRenderPipeline/Lit/FORWARD"
-        UsePass "HDRenderPipeline/Lit/TRANSPARENTDEPTHPOSTPASS"
+        UsePass "HDRP/Lit/SCENESELECTIONPASS"
+        UsePass "HDRP/Lit/GBUFFER"
+        UsePass "HDRP/Lit/META"
+        UsePass "HDRP/Lit/SHADOWCASTER"
+        UsePass "HDRP/Lit/DEPTHONLY"
+        UsePass "HDRP/Lit/DISTORTIONVECTORS"
+        UsePass "HDRP/Lit/TRANSPARENTDEPTHPREPASS"
+        UsePass "HDRP/Lit/TRANSPARENTBACKFACE"
+        UsePass "HDRP/Lit/FORWARD"
+        UsePass "HDRP/Lit/TRANSPARENTDEPTHPOSTPASS"
+
 
         // Alembic: Override the MotionVectors pass to integrate runtime velocities.
         /////////////////////////////////////////////////////////////////////////////
         Pass
         {
-            Name "Motion Vectors"
+            Name "MotionVectors"
             Tags{ "LightMode" = "MotionVectors" } // Caution, this need to be call like this to setup the correct parameters by C++ (legacy Unity)
 
             // If velocity pass (motion vectors) is enabled we tag the stencil so it don't perform CameraMotionVelocity

--- a/com.unity.formats.alembic/Runtime/Shaders/StandardRoughness.shader
+++ b/com.unity.formats.alembic/Runtime/Shaders/StandardRoughness.shader
@@ -53,11 +53,11 @@ Shader "Alembic/Standard (Roughness setup)"
         Tags { "RenderType"="Opaque" "PerformanceChecks"="False" }
 
         UsePass "Hidden/Alembic/MotionVectors/MOTIONVECTORS"
-        UsePass "Standard (Roughness setup)/FORWARD"
-        UsePass "Standard (Roughness setup)/FORWARD_DELTA"
-        UsePass "Standard (Roughness setup)/SHADOWCASTER"
-        UsePass "Standard (Roughness setup)/DEFERRED"
-        UsePass "Standard (Roughness setup)/META"
+        UsePass "Autodesk Interactive/FORWARD"
+        UsePass "Autodesk Interactive/FORWARD_DELTA"
+        UsePass "Autodesk Interactive/SHADOWCASTER"
+        UsePass "Autodesk Interactive/DEFERRED"
+        UsePass "Autodesk Interactive/META"
     }
 
     CustomEditor "StandardRoughnessShaderGUI"


### PR DESCRIPTION
This branch updates the LitAlembic material to work with hdrp4.10
Starting with 2019.2 the HDRP materials support the features alembic needs and should be used instead of LitAlembic.