### PR TITLE
Replace string queries with GUID for DummyAlembic.abc

### DIFF
--- a/com.unity.formats.alembic/Tests/Editor/AssetRenameTests.cs
+++ b/com.unity.formats.alembic/Tests/Editor/AssetRenameTests.cs
@@ -17,7 +17,9 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         [SetUp]
         public void SetUp()
         {
-            var srcDummyFile = AssetDatabase.FindAssets("Dummy").Select(AssetDatabase.GUIDToAssetPath).SelectMany(AssetDatabase.LoadAllAssetsAtPath).OfType<AlembicStreamPlayer>().First().StreamDescriptor.PathToAbc;
+            const string dummyGUID = "1a066d124049a413fb12b82470b82811"; // GUID of DummyAlembic.abc
+            var path = AssetDatabase.GUIDToAssetPath(dummyGUID);
+            var srcDummyFile = AssetDatabase.LoadAllAssetsAtPath(path).OfType<AlembicStreamPlayer>().First().StreamDescriptor.PathToAbc;
             File.Copy(srcDummyFile,copiedAbcFile, true);
             AssetDatabase.Refresh();
             var asset = AssetDatabase.LoadMainAssetAtPath(copiedAbcFile);


### PR DESCRIPTION
For some reason tests were failing on 2018.4 on Yamato when searching for the Alembic asset.
This branch changes the asset GUID.