### PR TITLE
Linux hdf5

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -15,7 +15,7 @@ if(WIN32)
 elseif(APPLE)
     set(HDF5_LIBRARIES "${HDF5_LIBRARIES};-ldl;-lpthread;${HDF5_ROOT}/lib/libz.a;${HDF5_ROOT}/lib/libszip.a")
 else()
-    set(HDF5_LIBRARIES "${HDF5_LIBRARIES};-ldl;-lpthread")
+    set(HDF5_LIBRARIES "${HDF5_LIBRARIES};-ldl;-lpthread;${HDF5_ROOT}/lib/libz.a;${HDF5_ROOT}/lib/libszip.a")
 endif()
 
 if(APPLE OR UNIX)

--- a/buildingOnCentOS
+++ b/buildingOnCentOS
@@ -1,4 +1,4 @@
 need to install cmake3 make a symlink in ~ and update PATH
 sudo yum install centos-release-scl
- sudo yum install devtoolset-7
-scl enable devtoolset-7 bash
+ sudo yum install devtoolset-6
+scl enable devtoolset-6 bash

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Fixed the LitAlembic material compatibility with HDRP 4.10 (latest 2018.4 version). For 2019.2+ HDRP standard materials support vertex motion vectors.
 -Fixed Vertex colour import from Houdini.
 
+### Known Issues
+- HDF5 is not supported under Linux for import or export. 
+
 
 ## [1.0.5] - 2019-05-10
 ### Changes

--- a/com.unity.formats.alembic/Editor/Exporter/AlembicExporterEditor.cs
+++ b/com.unity.formats.alembic/Editor/Exporter/AlembicExporterEditor.cs
@@ -63,7 +63,9 @@ namespace UnityEditor.Formats.Alembic.Exporter
             // alembic settings
             EditorGUILayout.LabelField("Alembic Settings", EditorStyles.boldLabel);
             {
+#if !UNITY_EDITOR_LINUX
                 EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "conf.archiveType"));
+#endif
                 EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "conf.xformType"));
                 var timeSamplingType = so.FindProperty(pathSettings + "conf.timeSamplingType");
                 EditorGUILayout.PropertyField(timeSamplingType);

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -92,7 +92,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             yield return TestCubeContents(go);
         }
 
-        [UnityTest]
+        [UnityTest, UnityPlatform(exclude = new[]{RuntimePlatform.LinuxEditor})]
         public IEnumerator TestArchiveType([Values(aeArchiveType.Ogawa, aeArchiveType.HDF5)] int archiveType)
         {
             director.Play();


### PR DESCRIPTION
Disable the HDF5 export support on Linux temporarily until we decide if we drop support altogether.
Importing of HDF5 files will most likely fail with a generic error: "Cannot load file"
I cannot detect the file format beforehand in order to print a more specific error message.