### PR TITLE
Public api

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,12 +1,11 @@
 editors:
-  - version: 2018.4
   - version: 2019.2
-  - version: 2019.3  
+  - version: trunk
 platforms:
   - name: win
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: b1.large
+    flavor: m1.large
   - name: mac
     type: Unity::VM::osx
     image: buildfarm/mac:stable
@@ -17,7 +16,7 @@ build_win:
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: b1.large
+    flavor: m1.large
   commands:
     - git submodule update --init --recursive
     - build.cmd
@@ -45,7 +44,7 @@ pack:
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: b1.large
+    flavor: m1.large
   commands:
     - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack --package-path com.unity.formats.alembic
@@ -90,7 +89,7 @@ test_trigger:
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: b1.large
+    flavor: m1.large
   commands:
     - dir
   triggers:
@@ -119,7 +118,7 @@ publish:
   agent:
     type: Unity::VM
     image: package-ci/win10:latest
-    flavor: b1.large
+    flavor: m1.large
     name: Runner
   commands:
     - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,11 +1,11 @@
 editors:
   - version: 2019.2
-  - version: trunk
+  - version: 2019.3  
 platforms:
   - name: win
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   - name: mac
     type: Unity::VM::osx
     image: buildfarm/mac:stable
@@ -16,7 +16,7 @@ build_win:
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   commands:
     - git submodule update --init --recursive
     - build.cmd
@@ -44,7 +44,7 @@ pack:
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   commands:
     - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack --package-path com.unity.formats.alembic
@@ -89,7 +89,7 @@ test_trigger:
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   commands:
     - dir
   triggers:
@@ -118,7 +118,7 @@ publish:
   agent:
     type: Unity::VM
     image: package-ci/win10:latest
-    flavor: m1.large
+    flavor: b1.large
     name: Runner
   commands:
     - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm

--- a/Source/abci/Importer/AlembicImporter.h
+++ b/Source/abci/Importer/AlembicImporter.h
@@ -30,7 +30,7 @@ class aiPolyMesh; // : aiSchema
 class aiPoints;   // : aiSchema
 class aiProperty;
 
-enum class aiNormalsMode
+enum class NormalsMode
 {
     //ReadFromFile,
     ComputeIfMissing = 1,
@@ -38,7 +38,7 @@ enum class aiNormalsMode
     //Ignore
 };
 
-enum class aiTangentsMode
+enum class TangentsMode
 {
     None,
     Compute,
@@ -99,8 +99,8 @@ enum class aiPropertyType
 
 struct aiConfig
 {
-    aiNormalsMode normals_mode = aiNormalsMode::ComputeIfMissing;
-    aiTangentsMode tangents_mode = aiTangentsMode::None;
+    NormalsMode normals_mode = NormalsMode::ComputeIfMissing;
+    TangentsMode tangents_mode = TangentsMode::None;
     float scale_factor = 1.0f;
     float aspect_ratio = -1.0f;
     float vertex_motion_scale = 1.0f;

--- a/Source/abci/Importer/AlembicImporter.h
+++ b/Source/abci/Importer/AlembicImporter.h
@@ -32,10 +32,10 @@ class aiProperty;
 
 enum class aiNormalsMode
 {
-    ReadFromFile,
-    ComputeIfMissing,
-    AlwaysCompute,
-    Ignore
+    //ReadFromFile,
+    ComputeIfMissing = 1,
+    AlwaysCompute = 2,
+    //Ignore
 };
 
 enum class aiTangentsMode

--- a/Source/abci/Importer/aiPolyMesh.cpp
+++ b/Source/abci/Importer/aiPolyMesh.cpp
@@ -370,7 +370,7 @@ void aiPolyMesh::updateSummary()
         {
             summary.has_normals_prop = true;
             summary.has_normals = true;
-            summary.constant_normals = param.isConstant() && config.normals_mode != aiNormalsMode::AlwaysCompute;
+            summary.constant_normals = param.isConstant() && config.normals_mode != NormalsMode::AlwaysCompute;
             if (!summary.constant_normals)
                 m_constant = false;
         }
@@ -451,15 +451,15 @@ void aiPolyMesh::updateSummary()
     // normals - interpolate or compute?
     if (!summary.constant_normals)
     {
-        if (summary.has_normals && config.normals_mode != aiNormalsMode::AlwaysCompute)
+        if (summary.has_normals && config.normals_mode != NormalsMode::AlwaysCompute)
         {
             summary.interpolate_normals = interpolate;
         }
         else
         {
             summary.compute_normals =
-                config.normals_mode == aiNormalsMode::AlwaysCompute ||
-                (!summary.has_normals && config.normals_mode == aiNormalsMode::ComputeIfMissing);
+                    config.normals_mode == NormalsMode::AlwaysCompute ||
+                    (!summary.has_normals && config.normals_mode == NormalsMode::ComputeIfMissing);
             if (summary.compute_normals)
             {
                 summary.has_normals = true;
@@ -469,7 +469,7 @@ void aiPolyMesh::updateSummary()
     }
 
     // tangents
-    if (config.tangents_mode == aiTangentsMode::Compute && summary.has_normals && summary.has_uv0)
+    if (config.tangents_mode == TangentsMode::Compute && summary.has_normals && summary.has_uv0)
     {
         summary.has_tangents = true;
         summary.compute_tangents = true;

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changes in Alembic for Unity
 ## [2.0.0-preview.1] - 2019-08-07
 ### Changes
-- Introduced public API for Alembic playback and recording
+- Introduced public API for Alembic playback and recording. Bumped minimum Unity
+  version to 2019.2
 
 ## [1.0.6] - 2019-08-26
 ### Changes

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changes in Alembic for Unity
+## [2.0.0-preview.1] - 2019-08-07
+### Changes
+- Introduced public API for Alembic playback and recording
+
 ## [1.0.6] - 2019-08-26
 ### Changes
 - Added support for Linux

--- a/com.unity.formats.alembic/Documentation~/ref_StreamPlayer.md
+++ b/com.unity.formats.alembic/Documentation~/ref_StreamPlayer.md
@@ -11,4 +11,3 @@ The Alembic Stream Player component allows you to customize import and playback.
 | __Vertex Motion Scale__    | Set the magnification factor when calculating velocity. Greater velocity means more blurring when used with Motion Blur. By default, the value is set to 1 (the velocity is not scaled). |
 | __Async Load__             | Enable this option to load the file asynchronously during playback. |
 
-> ***Note:*** Unity creates copies of .abc files under `Assets / StreamingAssets`. This is necessary for streaming data, which requires that the .abc files remain after building the project.

--- a/com.unity.formats.alembic/Editor/Exporter/AlembicExporterEditor.cs
+++ b/com.unity.formats.alembic/Editor/Exporter/AlembicExporterEditor.cs
@@ -19,8 +19,8 @@ namespace UnityEditor.Formats.Alembic.Exporter
         public override void OnInspectorGUI()
         {
             var t = target as AlembicExporter;
-            var recorder = t.recorder;
-            var settings = recorder.settings;
+            var recorder = t.Recorder;
+            var settings = recorder.Settings;
             var so = serializedObject;
 
             bool dirty = false;
@@ -69,7 +69,7 @@ namespace UnityEditor.Formats.Alembic.Exporter
                 EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "conf.xformType"));
                 var timeSamplingType = so.FindProperty(pathSettings + "conf.timeSamplingType");
                 EditorGUILayout.PropertyField(timeSamplingType);
-                if (timeSamplingType.intValue == (int)aeTimeSamplingType.Uniform)
+                if (timeSamplingType.intValue == (int)TimeSamplingType.Uniform)
                 {
                     EditorGUI.indentLevel++;
                     EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "conf.frameRate"));
@@ -151,7 +151,7 @@ namespace UnityEditor.Formats.Alembic.Exporter
             {
                 // capture control
                 EditorGUILayout.LabelField("Capture Control", EditorStyles.boldLabel);
-                if (recorder.recording)
+                if (recorder.Recording)
                 {
                     if (GUILayout.Button("End Recording"))
                         t.EndRecording();

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -341,11 +341,11 @@ namespace UnityEditor.Formats.Alembic.Importer
             if (apr != null)
             {
                 var cubeGO = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                apr.sharedMesh = cubeGO.GetComponent<MeshFilter>().sharedMesh;
+                apr.InstancedMesh = cubeGO.GetComponent<MeshFilter>().sharedMesh;
                 DestroyImmediate(cubeGO);
 
-                apr.SetSharedMaterials(new Material[] { subassets.pointsMaterial });
-                apr.motionVectorMaterial = subassets.pointsMotionVectorMaterial;
+                apr.Materials = new List<Material> { subassets.pointsMaterial };
+                apr.MotionVectorMaterial = subassets.pointsMotionVectorMaterial;
             }
 
             foreach (var child in node.Children)

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -159,15 +159,15 @@ namespace UnityEditor.Formats.Alembic.Importer
             using (var abcStream = new AlembicStream(go, streamDescriptor))
             {
                 abcStream.AbcLoad(true, true);
-
-                abcStream.GetTimeRange(ref abcStartTime, ref abcEndTime);
+                double start, end;
+                abcStream.GetTimeRange(out start, out end);
                 if (firstImport)
                 {
-                    startTime = abcStartTime;
-                    endTime = abcEndTime;
+                    startTime = start;
+                    endTime = end;
                 }
-                streamDescriptor.abcStartTime = abcStartTime;
-                streamDescriptor.abcEndTime = abcEndTime;
+                streamDescriptor.mediaStartTime = (float)start;
+                streamDescriptor.mediaEndTime = (float)end;
 
                 var streamPlayer = go.AddComponent<AlembicStreamPlayer>();
                 streamPlayer.StreamDescriptor = streamDescriptor;

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -159,15 +159,14 @@ namespace UnityEditor.Formats.Alembic.Importer
             using (var abcStream = new AlembicStream(go, streamDescriptor))
             {
                 abcStream.AbcLoad(true, true);
-                double start, end;
-                abcStream.GetTimeRange(out start, out end);
+                abcStream.GetTimeRange(out abcStartTime, out abcEndTime);
                 if (firstImport)
                 {
-                    startTime = start;
-                    endTime = end;
+                    startTime = abcStartTime;
+                    endTime = abcEndTime;
                 }
-                streamDescriptor.mediaStartTime = (float)start;
-                streamDescriptor.mediaEndTime = (float)end;
+                streamDescriptor.mediaStartTime = (float)abcStartTime;
+                streamDescriptor.mediaEndTime = (float)abcEndTime;
 
                 var streamPlayer = go.AddComponent<AlembicStreamPlayer>();
                 streamPlayer.StreamDescriptor = streamDescriptor;

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -271,7 +271,7 @@ namespace UnityEditor.Formats.Alembic.Importer
 
         void GenerateSubAssets(Subassets subassets, AlembicTreeNode root, AlembicStreamDescriptor streamDescr)
         {
-            if (streamDescr.duration > 0)
+            if (streamDescr.mediaDuration > 0)
             {
                 // AnimationClip for time
                 {
@@ -279,8 +279,8 @@ namespace UnityEditor.Formats.Alembic.Importer
                     frames[0].value = 0.0f;
                     frames[0].time = 0.0f;
                     frames[0].outTangent = 1.0f;
-                    frames[1].value = (float)streamDescr.duration;
-                    frames[1].time = (float)streamDescr.duration;
+                    frames[1].value = (float)streamDescr.mediaDuration;
+                    frames[1].time = (float)streamDescr.mediaDuration;
                     frames[1].inTangent = 1.0f;
 
                     var curve = new AnimationCurve(frames);

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -182,8 +182,8 @@ namespace UnityEditor.Formats.Alembic.Importer
 
                 var streamPlayer = go.AddComponent<AlembicStreamPlayer>();
                 streamPlayer.StreamDescriptor = streamDescriptor;
-                streamPlayer.StartTime = StartTime;
-                streamPlayer.EndTime = EndTime;
+                streamPlayer.StartTime = (float)StartTime;
+                streamPlayer.EndTime = (float)EndTime;
 
                 var subassets = new Subassets(ctx);
                 subassets.Add(streamDescriptor.name, streamDescriptor);

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -118,18 +118,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             get { return importWarning; }
             set { importWarning = value; }
         }
-        [SerializeField]
-        private List<string> varyingTopologyMeshNames = new List<string>();
-        public List<string> VaryingTopologyMeshNames
-        {
-            get { return varyingTopologyMeshNames; }
-        }
-        [SerializeField]
-        private List<string> splittingMeshNames = new List<string>();
-        public List<string> SplittingMeshNames
-        {
-            get { return splittingMeshNames; }
-        }
+
         [SerializeField] bool firstImport = true;
 
         void OnValidate()
@@ -324,26 +313,12 @@ namespace UnityEditor.Formats.Alembic.Importer
                     }
                 }
             }
-            varyingTopologyMeshNames = new List<string>();
-            splittingMeshNames = new List<string>();
 
             CollectSubAssets(subassets, root);
-
-            streamDescr.HasVaryingTopology = VaryingTopologyMeshNames.Count > 0;
         }
 
         void CollectSubAssets(Subassets subassets, AlembicTreeNode node)
         {
-            var mesh = node.GetAlembicObj<AlembicMesh>();
-            if (mesh != null)
-            {
-                var sum = mesh.summary;
-                if (mesh.summary.topologyVariance == aiTopologyVariance.Heterogeneous)
-                    VaryingTopologyMeshNames.Add(node.gameObject.name);
-                else if (mesh.sampleSummary.splitCount > 1)
-                    SplittingMeshNames.Add(node.gameObject.name);
-            }
-
             int submeshCount = 0;
             var meshFilter = node.gameObject.GetComponent<MeshFilter>();
             if (meshFilter != null)

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -279,8 +279,8 @@ namespace UnityEditor.Formats.Alembic.Importer
                     frames[0].value = 0.0f;
                     frames[0].time = 0.0f;
                     frames[0].outTangent = 1.0f;
-                    frames[1].value = (float)streamDescr.mediaDuration;
-                    frames[1].time = (float)streamDescr.mediaDuration;
+                    frames[1].value = streamDescr.mediaDuration;
+                    frames[1].time = streamDescr.mediaDuration;
                     frames[1].inTangent = 1.0f;
 
                     var curve = new AnimationCurve(frames);

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporterEditor.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporterEditor.cs
@@ -88,8 +88,8 @@ namespace UnityEditor.Formats.Alembic.Importer
             EditorGUILayout.LabelField("Geometry", EditorStyles.boldLabel);
             {
                 EditorGUI.indentLevel++;
-                DisplayEnumProperty(serializedObject.FindProperty(pathSettings + "normals"), Enum.GetNames(typeof(aiNormalsMode)));
-                DisplayEnumProperty(serializedObject.FindProperty(pathSettings + "tangents"), Enum.GetNames(typeof(aiTangentsMode)));
+                DisplayEnumProperty(serializedObject.FindProperty(pathSettings + "normals"), Enum.GetNames(typeof(NormalsMode)));
+                DisplayEnumProperty(serializedObject.FindProperty(pathSettings + "tangents"), Enum.GetNames(typeof(TangentsMode)));
                 EditorGUILayout.PropertyField(serializedObject.FindProperty(pathSettings + "flipFaces"));
                 EditorGUI.indentLevel--;
             }
@@ -98,7 +98,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             EditorGUILayout.LabelField("Cameras", EditorStyles.boldLabel);
             {
                 EditorGUI.indentLevel++;
-                DisplayEnumProperty(serializedObject.FindProperty(pathSettings + "cameraAspectRatio"), Enum.GetNames(typeof(aiAspectRatioMode)),
+                DisplayEnumProperty(serializedObject.FindProperty(pathSettings + "cameraAspectRatio"), Enum.GetNames(typeof(AspectRatioMode)),
                     new GUIContent("Aspect Ratio", ""));
                 EditorGUI.indentLevel--;
             }

--- a/com.unity.formats.alembic/Editor/Importer/AlembicStreamPlayerEditor.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicStreamPlayerEditor.cs
@@ -38,10 +38,10 @@ namespace UnityEditor.Formats.Alembic.Importer
             EditorGUILayout.LabelField(new GUIContent("Time Range"));
             EditorGUI.BeginDisabledGroup(multipleTimeRanges);
 
-            var abcStart = (float)targetStreamDesc.abcStartTime;
-            var abcEnd = (float)targetStreamDesc.abcEndTime;
-            var start = (float)streamPlayer.StartTime;
-            var end = (float)streamPlayer.EndTime;
+            var abcStart = targetStreamDesc.mediaStartTime;
+            var abcEnd = targetStreamDesc.mediaEndTime;
+            var start = streamPlayer.StartTime;
+            var end = streamPlayer.EndTime;
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.MinMaxSlider(" ", ref start, ref end, abcStart, abcEnd);
             if (EditorGUI.EndChangeCheck())

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -69,73 +69,57 @@ namespace UnityEngine.Formats.Alembic.Sdk
     };
 
     [Serializable]
-    public struct aeConfig
+    [StructLayout(LayoutKind.Sequential)]
+    public class aeConfig
     {
         [SerializeField]
-        private aeArchiveType archiveType;
+        private aeArchiveType archiveType = aeArchiveType.Ogawa;
         public aeArchiveType ArchiveType
         {
             get { return archiveType; }
             set { archiveType = value; }
         }
         [SerializeField]
-        private aeTimeSamplingType timeSamplingType;
+        private aeTimeSamplingType timeSamplingType = aeTimeSamplingType.Uniform;
         public aeTimeSamplingType TimeSamplingType
         {
             get { return timeSamplingType; }
             set { timeSamplingType = value; }
         }
         [SerializeField]
-        private float frameRate;
+        private float frameRate = 30;
         public float FrameRate
         {
             get { return frameRate; }
             set { frameRate = Mathf.Max(value, Mathf.Epsilon); }
         }
         [SerializeField]
-        private aeXformType xformType;
+        private aeXformType xformType = aeXformType.TRS;
         public aeXformType XformType
         {
             get { return xformType; }
             set { xformType = value; }
         }
         [SerializeField]
-        private Bool swapHandedness;
+        private Bool swapHandedness = true;
         public bool SwapHandedness
         {
             get { return swapHandedness; }
             set { swapHandedness = value; }
         }
         [SerializeField]
-        private Bool swapFaces;
+        private Bool swapFaces = false;
         public bool SwapFaces
         {
             get { return swapFaces; }
             set { swapFaces = value; }
         }
         [SerializeField]
-        private float scaleFactor;
+        private float scaleFactor = 100;
         public float ScaleFactor
         {
             get { return scaleFactor; }
             set { scaleFactor = value; }
-        }
-
-        public static aeConfig defaultValue
-        {
-            get
-            {
-                return new aeConfig
-                {
-                    ArchiveType = aeArchiveType.Ogawa,
-                    TimeSamplingType = aeTimeSamplingType.Uniform,
-                    FrameRate = 30.0f,
-                    XformType = aeXformType.TRS,
-                    SwapHandedness = true,
-                    SwapFaces = false,
-                    ScaleFactor = 100.0f,
-                };
-            }
         }
     }
 
@@ -220,7 +204,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
 
         public static aeContext Create() { return NativeMethods.aeCreateContext(); }
         public void Destroy() { NativeMethods.aeDestroyContext(self); self = IntPtr.Zero; }
-        public void SetConfig(ref aeConfig conf) { NativeMethods.aeSetConfig(self, ref conf); }
+        public void SetConfig(aeConfig conf) { NativeMethods.aeSetConfig(self, conf); }
         public bool OpenArchive(string path) { return NativeMethods.aeOpenArchive(self, path); }
         public int AddTimeSampling(float start_time) { return NativeMethods.aeAddTimeSampling(self, start_time); }
         public void AddTime(float start_time) { NativeMethods.aeAddTime(self, start_time); }
@@ -291,7 +275,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         [DllImport(Abci.Lib)] public static extern aeContext aeCreateContext();
         [DllImport(Abci.Lib)] public static extern void aeDestroyContext(IntPtr ctx);
 
-        [DllImport(Abci.Lib)] public static extern void aeSetConfig(IntPtr ctx, ref aeConfig conf);
+        [DllImport(Abci.Lib)] public static extern void aeSetConfig(IntPtr ctx, aeConfig conf);
         [DllImport(Abci.Lib, BestFitMapping = false, ThrowOnUnmappableChar = true)] public static extern Bool aeOpenArchive(IntPtr ctx, string path);
         [DllImport(Abci.Lib)] public static extern aeObject aeGetTopObject(IntPtr ctx);
         [DllImport(Abci.Lib)] public static extern int aeAddTimeSampling(IntPtr ctx, float start_time);

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -122,7 +122,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
             get { return timeSamplingType; }
             set { timeSamplingType = value; }
         }
-        [SerializeField]
+        [HideInInspector,SerializeField]
         float frameRate = 30;
         /// <summary>
         /// The capture frame rate. This is available only with uniform sampling

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -338,7 +338,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         [DllImport(Abci.Lib)] public static extern void aiContextSetConfig(IntPtr ctx, ref aiConfig conf);
         [DllImport(Abci.Lib)] public static extern int aiContextGetTimeSamplingCount(IntPtr ctx);
         [DllImport(Abci.Lib)] public static extern aiTimeSampling aiContextGetTimeSampling(IntPtr ctx, int i);
-        [DllImport(Abci.Lib)] public static extern void aiContextGetTimeRange(IntPtr ctx, ref double begin, ref double end);
+        [DllImport(Abci.Lib)] public static extern void aiContextGetTimeRange(IntPtr ctx, out double begin, out double end);
         [DllImport(Abci.Lib)] public static extern aiObject aiContextGetTopObject(IntPtr ctx);
         [DllImport(Abci.Lib)] public static extern void aiContextUpdateSamples(IntPtr ctx, double time);
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -10,26 +10,26 @@ using UnityEngine;
 
 namespace UnityEngine.Formats.Alembic.Sdk
 {
-    enum aeArchiveType
+    public enum aeArchiveType
     {
         HDF5,
         Ogawa,
     };
 
-    enum aeTimeSamplingType
+    public enum aeTimeSamplingType
     {
         Uniform = 0,
         // Cyclic = 1,
         Acyclic = 2,
     };
 
-    enum aeXformType
+    public enum aeXformType
     {
         Matrix,
         TRS,
     };
 
-    enum aeTopology
+    public enum aeTopology
     {
         Points,
         Lines,
@@ -69,7 +69,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
     };
 
     [Serializable]
-    struct aeConfig
+    public struct aeConfig
     {
         [SerializeField]
         private aeArchiveType archiveType;
@@ -101,14 +101,14 @@ namespace UnityEngine.Formats.Alembic.Sdk
         }
         [SerializeField]
         private Bool swapHandedness;
-        public Bool SwapHandedness
+        public bool SwapHandedness
         {
             get { return swapHandedness; }
             set { swapHandedness = value; }
         }
         [SerializeField]
         private Bool swapFaces;
-        public Bool SwapFaces
+        public bool SwapFaces
         {
             get { return swapFaces; }
             set { swapFaces = value; }
@@ -276,7 +276,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
     }
 
 
-    static partial class AbcAPI
+    static class AbcAPI
     {
         public static void aeWaitMaxDeltaTime()
         {
@@ -286,7 +286,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         }
     }
 
-    internal static class NativeMethods
+    static class NativeMethods
     {
         [DllImport(Abci.Lib)] public static extern aeContext aeCreateContext();
         [DllImport(Abci.Lib)] public static extern void aeDestroyContext(IntPtr ctx);

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -90,7 +90,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public float FrameRate
         {
             get { return frameRate; }
-            set { frameRate = value; }
+            set { frameRate = Mathf.Max(value, Mathf.Epsilon); }
         }
         [SerializeField]
         private aeXformType xformType;

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -130,7 +130,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public float FrameRate
         {
             get { return frameRate; }
-            set { frameRate = Mathf.Max(value, Mathf.Epsilon); }
+            set { frameRate = Mathf.Max(value, Mathf.Epsilon); } // Prevent divisions by 0
         }
         [SerializeField]
         TransformType xformType = TransformType.TRS;

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -10,26 +10,53 @@ using UnityEngine;
 
 namespace UnityEngine.Formats.Alembic.Sdk
 {
-    public enum aeArchiveType
+    /// <summary>
+    /// Alembic archive type
+    /// </summary>
+    public enum ArchiveType
     {
+        /// <summary>
+        /// HDF5 format (Deprecated)
+        /// </summary>
         HDF5,
+        /// <summary>
+        /// Ogawa format
+        /// </summary>
         Ogawa,
     };
 
-    public enum aeTimeSamplingType
+    /// <summary>
+    /// Time sampling scheme for the Alembic file
+    /// </summary>
+    public enum TimeSamplingType
     {
+        /// <summary>
+        /// Uniform interval sampling
+        /// </summary>
         Uniform = 0,
         // Cyclic = 1,
+        /// <summary>
+        /// Arbitrary interval sampling
+        /// </summary>
         Acyclic = 2,
     };
 
-    public enum aeXformType
+    /// <summary>
+    /// Transform format
+    /// </summary>
+    public enum TransformType
     {
+        /// <summary>
+        /// Write the whole matrix transform
+        /// </summary>
         Matrix,
+        /// <summary>
+        /// Write animation in TRS format (translation, rotation, scale)
+        /// </summary>
         TRS,
     };
 
-    public enum aeTopology
+    enum aeTopology
     {
         Points,
         Lines,
@@ -68,54 +95,78 @@ namespace UnityEngine.Formats.Alembic.Sdk
         ArrayTypeEnd = Float4x4Array,
     };
 
+    /// <summary>
+    /// Class containing Alembic file format options.
+    /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public class aeConfig
+    public class AlembicExportOptions
     {
         [SerializeField]
-        private aeArchiveType archiveType = aeArchiveType.Ogawa;
-        public aeArchiveType ArchiveType
+        ArchiveType archiveType = ArchiveType.Ogawa;
+        /// <summary>
+        /// Alembic output file format type.
+        /// </summary>
+        public ArchiveType ArchiveType
         {
             get { return archiveType; }
             set { archiveType = value; }
         }
         [SerializeField]
-        private aeTimeSamplingType timeSamplingType = aeTimeSamplingType.Uniform;
-        public aeTimeSamplingType TimeSamplingType
+        TimeSamplingType timeSamplingType = TimeSamplingType.Uniform;
+        /// <summary>
+        /// The time sampling type (Uniform or Acyclic)
+        /// </summary>
+        public TimeSamplingType TimeSamplingType
         {
             get { return timeSamplingType; }
             set { timeSamplingType = value; }
         }
         [SerializeField]
-        private float frameRate = 30;
+        float frameRate = 30;
+        /// <summary>
+        /// The capture frame rate. This is available only with uniform sampling
+        /// </summary>
         public float FrameRate
         {
             get { return frameRate; }
             set { frameRate = Mathf.Max(value, Mathf.Epsilon); }
         }
         [SerializeField]
-        private aeXformType xformType = aeXformType.TRS;
-        public aeXformType XformType
+        TransformType xformType = TransformType.TRS;
+        /// <summary>
+        /// The transform format.
+        /// </summary>
+        public TransformType TranformType
         {
             get { return xformType; }
             set { xformType = value; }
         }
         [SerializeField]
-        private Bool swapHandedness = true;
+        Bool swapHandedness = true;
+        /// <summary>
+        /// Enable to change from a left hand coordinate system (Unity) to a right hand coordinate system (Autodesk® Maya®).
+        /// </summary>
         public bool SwapHandedness
         {
             get { return swapHandedness; }
             set { swapHandedness = value; }
         }
         [SerializeField]
-        private Bool swapFaces = false;
+        Bool swapFaces = false;
+        /// <summary>
+        /// Enable to reverse the front and back of all faces.
+        /// </summary>
         public bool SwapFaces
         {
             get { return swapFaces; }
             set { swapFaces = value; }
         }
         [SerializeField]
-        private float scaleFactor = 100;
+        float scaleFactor = 100;
+        /// <summary>
+        /// Set scale factor to convert between different system units. For example, using 0.1 converts the Unity units to 1/10 of their value in the resulting Alembic file. This also affects position and speed.
+        /// </summary>
         public float ScaleFactor
         {
             get { return scaleFactor; }
@@ -204,7 +255,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
 
         public static aeContext Create() { return NativeMethods.aeCreateContext(); }
         public void Destroy() { NativeMethods.aeDestroyContext(self); self = IntPtr.Zero; }
-        public void SetConfig(aeConfig conf) { NativeMethods.aeSetConfig(self, conf); }
+        public void SetConfig(AlembicExportOptions conf) { NativeMethods.aeSetConfig(self, conf); }
         public bool OpenArchive(string path) { return NativeMethods.aeOpenArchive(self, path); }
         public int AddTimeSampling(float start_time) { return NativeMethods.aeAddTimeSampling(self, start_time); }
         public void AddTime(float start_time) { NativeMethods.aeAddTime(self, start_time); }
@@ -275,7 +326,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         [DllImport(Abci.Lib)] public static extern aeContext aeCreateContext();
         [DllImport(Abci.Lib)] public static extern void aeDestroyContext(IntPtr ctx);
 
-        [DllImport(Abci.Lib)] public static extern void aeSetConfig(IntPtr ctx, aeConfig conf);
+        [DllImport(Abci.Lib)] public static extern void aeSetConfig(IntPtr ctx, AlembicExportOptions conf);
         [DllImport(Abci.Lib, BestFitMapping = false, ThrowOnUnmappableChar = true)] public static extern Bool aeOpenArchive(IntPtr ctx, string path);
         [DllImport(Abci.Lib)] public static extern aeObject aeGetTopObject(IntPtr ctx);
         [DllImport(Abci.Lib)] public static extern int aeAddTimeSampling(IntPtr ctx, float start_time);

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -13,7 +13,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
     /// <summary>
     /// Alembic archive type
     /// </summary>
-    public enum ArchiveType
+    internal enum ArchiveType
     {
         /// <summary>
         /// HDF5 format (Deprecated)
@@ -107,7 +107,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         /// <summary>
         /// Alembic output file format type.
         /// </summary>
-        public ArchiveType ArchiveType
+        internal ArchiveType ArchiveType
         {
             get { return archiveType; }
             set { archiveType = value; }

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter.cs
@@ -7,8 +7,11 @@ using UnityEngine.Formats.Alembic.Util;
 
 namespace UnityEngine.Formats.Alembic.Exporter
 {
+    /// <summary>
+    /// Component that records the Unity Scene state and exports as an Alembic file. This class records only in Playmode.
+    /// </summary>
     [ExecuteInEditMode]
-    internal class AlembicExporter : MonoBehaviour
+    public class AlembicExporter : MonoBehaviour
     {
         #region fields
         [SerializeField] AlembicRecorder m_recorder = new AlembicRecorder();
@@ -21,10 +24,22 @@ namespace UnityEngine.Formats.Alembic.Exporter
 
 
         #region properties
-        public AlembicRecorder recorder { get { return m_recorder; } }
-        public bool captureOnStart { get { return m_captureOnStart; } set { m_captureOnStart = value; } }
-        public bool ignoreFirstFrame { get { return m_ignoreFirstFrame; } set { m_ignoreFirstFrame = value; } }
-        public int maxCaptureFrame { get { return m_maxCaptureFrame; } set { m_maxCaptureFrame = value; } }
+        /// <summary>
+        /// Reference to the alembic recorder (lower level class that implements most of the functionality)
+        /// </summary>
+        public AlembicRecorder Recorder { get { return m_recorder; } }
+        /// <summary>
+        /// If true, start capturing immediately after entering play mode.
+        /// </summary>
+        public bool CaptureOnStart { get { return m_captureOnStart; } set { m_captureOnStart = value; } }
+        /// <summary>
+        /// If set, ignores the first frame.
+        /// </summary>
+        public bool IgnoreFirstFrame { get { return m_ignoreFirstFrame; } set { m_ignoreFirstFrame = value; } }
+        /// <summary>
+        /// Number of frames to capture. If set to 0, captures indefinitely.
+        /// </summary>
+        public int MaxCaptureFrame { get { return m_maxCaptureFrame; } set { m_maxCaptureFrame = value; } }
         #endregion
 
 
@@ -32,7 +47,7 @@ namespace UnityEngine.Formats.Alembic.Exporter
 
         void InitializeOutputPath()
         {
-            var settings = m_recorder.settings;
+            var settings = m_recorder.Settings;
             if (string.IsNullOrEmpty(settings.OutputPath))
             {
                 settings.OutputPath = "Output/" + gameObject.name + ".abc";
@@ -43,7 +58,7 @@ namespace UnityEngine.Formats.Alembic.Exporter
         {
             yield return new WaitForEndOfFrame();
 
-            if (!m_recorder.recording || Time.frameCount == m_prevFrame) { yield break; }
+            if (!m_recorder.Recording || Time.frameCount == m_prevFrame) { yield break; }
             m_prevFrame = Time.frameCount;
             if (m_captureOnStart && m_ignoreFirstFrame && m_firstFrame)
             {
@@ -53,7 +68,7 @@ namespace UnityEngine.Formats.Alembic.Exporter
 
             m_recorder.ProcessRecording();
 
-            if (m_maxCaptureFrame > 0 && m_recorder.frameCount >= m_maxCaptureFrame)
+            if (m_maxCaptureFrame > 0 && m_recorder.FrameCount >= m_maxCaptureFrame)
                 EndRecording();
         }
 
@@ -61,6 +76,9 @@ namespace UnityEngine.Formats.Alembic.Exporter
 
 
         #region public methods
+        /// <summary>
+        /// Starts a recording session.
+        /// </summary>
         public void BeginRecording()
         {
             m_firstFrame = true;
@@ -68,11 +86,17 @@ namespace UnityEngine.Formats.Alembic.Exporter
             m_recorder.BeginRecording();
         }
 
+        /// <summary>
+        /// Ends a recording session.
+        /// </summary>
         public void EndRecording()
         {
             m_recorder.EndRecording();
         }
 
+        /// <summary>
+        /// Exports only 1 frame.
+        /// </summary>
         public void OneShot()
         {
             BeginRecording();
@@ -112,7 +136,7 @@ namespace UnityEngine.Formats.Alembic.Exporter
 
         void Update()
         {
-            if (m_recorder.recording)
+            if (m_recorder.Recording)
             {
                 StartCoroutine(ProcessRecording());
             }
@@ -125,7 +149,7 @@ namespace UnityEngine.Formats.Alembic.Exporter
 
         void OnDestroy()
         {
-            if (recorder != null) recorder.Dispose();
+            if (Recorder != null) Recorder.Dispose();
         }
 
         #endregion

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -30,7 +30,7 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        public aeConfig conf = aeConfig.defaultValue;
+        public aeConfig conf = new aeConfig();
 
         [SerializeField]
         private ExportScope scope = ExportScope.EntireScene;
@@ -942,7 +942,7 @@ namespace UnityEngine.Formats.Alembic.Util
                 return false;
             }
 
-            m_ctx.SetConfig(ref m_settings.conf);
+            m_ctx.SetConfig(m_settings.conf);
             if (!m_ctx.OpenArchive(m_settings.OutputPath))
             {
                 Debug.LogWarning("AlembicRecorder: failed to open file " + m_settings.OutputPath);

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -11,18 +11,32 @@ using UnityEngine.Formats.Alembic.Sdk;
 
 namespace UnityEngine.Formats.Alembic.Util
 {
+    /// <summary>
+    /// Controls the scope of Alembic export.
+    /// </summary>
     public enum ExportScope
     {
+        /// <summary>
+        /// Export the entire Scene.
+        /// </summary>
         EntireScene,
+        /// <summary>
+        /// Export only a branch (or hierarchy) of the Scene.
+        /// </summary>
         TargetBranch,
     }
-
-
+    
+    /// <summary>
+    /// Settings controlling different aspects of recording.
+    /// </summary>
     [Serializable]
     public class AlembicRecorderSettings
     {
         [SerializeField]
-        private string outputPath = "Output/Output.abc";
+        string outputPath = "Output/Output.abc";
+        /// <summary>
+        /// Specify the location to save the Alembic file to.
+        /// </summary>
         public string OutputPath
         {
             get { return outputPath; }
@@ -30,10 +44,18 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        public aeConfig conf = new aeConfig();
+        AlembicExportOptions conf = new AlembicExportOptions();
+
+        /// <summary>
+        /// Alembic file options (archive type, transform format, etc)
+        /// </summary>
+        public AlembicExportOptions exportOptions => conf;
 
         [SerializeField]
-        private ExportScope scope = ExportScope.EntireScene;
+        ExportScope scope = ExportScope.EntireScene;
+        /// <summary>
+        /// Choose the scope of the export.
+        /// </summary>
         public ExportScope Scope
         {
             get { return scope; }
@@ -41,7 +63,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private GameObject targetBranch;
+        GameObject targetBranch;
+        /// <summary>
+        /// Export only a branch (or hierarchy) of the Scene. This options is used only if Export Scope is set to Branch.
+        /// </summary>
         public GameObject TargetBranch
         {
             get { return targetBranch; }
@@ -49,7 +74,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool fixDeltaTime = true;
+        bool fixDeltaTime = true;
+        /// <summary>
+        /// Enable this option to set Time.maximumDeltaTime using the frame rate to ensure fixed delta time.
+        /// </summary>
         public bool FixDeltaTime
         {
             get { return fixDeltaTime; }
@@ -58,7 +86,10 @@ namespace UnityEngine.Formats.Alembic.Util
 
         [SerializeField]
         [Tooltip("Assume only GameObjects with a SkinnedMeshRenderer component change over time.")]
-        private bool assumeNonSkinnedMeshesAreConstant = true;
+        bool assumeNonSkinnedMeshesAreConstant = true;
+        /// <summary>
+        /// Enable this option to skip capturing animation on static Meshes.
+        /// </summary>
         public bool AssumeNonSkinnedMeshesAreConstant
         {
             get { return assumeNonSkinnedMeshesAreConstant; }
@@ -66,7 +97,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool captureMeshRenderer = true;
+        bool captureMeshRenderer = true;
+        /// <summary>
+        /// Enable to capture Meshes.
+        /// </summary>
         public bool CaptureMeshRenderer
         {
             get { return captureMeshRenderer; }
@@ -74,7 +108,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool captureSkinnedMeshRenderer = true;
+        bool captureSkinnedMeshRenderer = true;
+        /// <summary>
+        /// Enable to capture Skinned Meshes.
+        /// </summary>
         public bool CaptureSkinnedMeshRenderer
         {
             get { return captureSkinnedMeshRenderer; }
@@ -82,15 +119,18 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool captureParticleSystem = false;
-        public bool CaptureParticleSystem
+        bool captureParticleSystem = false;
+        internal bool CaptureParticleSystem // Need to confirm is working.
         {
             get { return captureParticleSystem; }
             set { captureParticleSystem = value; }
         }
 
         [SerializeField]
-        private bool captureCamera = true;
+        bool captureCamera = true;
+        /// <summary>
+        /// Enable to capture Cameras.
+        /// </summary>
         public bool CaptureCamera
         {
             get { return captureCamera; }
@@ -98,7 +138,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool meshNormals = true;
+        bool meshNormals = true;
+        /// <summary>
+        /// Enable to export Mesh normals.
+        /// </summary>
         public bool MeshNormals
         {
             get { return meshNormals; }
@@ -106,7 +149,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool meshUV0 = true;
+        bool meshUV0 = true;
+        /// <summary>
+        /// Enable to export Mesh UV0.
+        /// </summary>
         public bool MeshUV0
         {
             get { return meshUV0; }
@@ -114,7 +160,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool meshUV1 = true;
+        bool meshUV1 = true;
+        /// <summary>
+        /// Enable to export Mesh UV1.
+        /// </summary>
         public bool MeshUV1
         {
             get { return meshUV1; }
@@ -122,7 +171,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool meshColors = true;
+        bool meshColors = true;
+        /// <summary>
+        /// Enable to export Mesh Vertex Colour.
+        /// </summary>
         public bool MeshColors
         {
             get { return meshColors; }
@@ -130,7 +182,10 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool meshSubmeshes = true;
+        bool meshSubmeshes = true;
+        /// <summary>
+        /// Enable to export sub-Meshes.
+        /// </summary>
         public bool MeshSubmeshes
         {
             get { return meshSubmeshes; }
@@ -138,19 +193,14 @@ namespace UnityEngine.Formats.Alembic.Util
         }
 
         [SerializeField]
-        private bool detailedLog = false;
+        bool detailedLog = false;
+        /// <summary>
+        /// Enable the Detailed Log option to provide Debug logging for each captured frame.
+        /// </summary>
         public bool DetailedLog
         {
             get { return detailedLog; }
             set { detailedLog = value; }
-        }
-
-        [SerializeField]
-        private bool debugLog = false;
-        public bool DebugLog
-        {
-            get { return debugLog; }
-            set { debugLog = value; }
         }
     }
 
@@ -179,6 +229,9 @@ namespace UnityEngine.Formats.Alembic.Util
     }
 
 
+    /// <summary>
+    /// Class that implements recording of Unity scene elements in the Alembic format.
+    /// </summary>
     [Serializable]
     public sealed class AlembicRecorder : IDisposable
     {
@@ -524,7 +577,7 @@ namespace UnityEngine.Formats.Alembic.Util
                     return;
 
                 abcObject = parent.abcObject.NewPolyMesh(m_target.name, timeSamplingIndex);
-                if (recorder.settings.MeshSubmeshes)
+                if (recorder.Settings.MeshSubmeshes)
                     m_mbuf.SetupSubmeshes(abcObject, mesh);
             }
 
@@ -569,7 +622,7 @@ namespace UnityEngine.Formats.Alembic.Util
                     return;
 
                 abcObject = parent.abcObject.NewPolyMesh(target.name, timeSamplingIndex);
-                if (recorder.settings.MeshSubmeshes)
+                if (recorder.Settings.MeshSubmeshes)
                     m_mbuf.SetupSubmeshes(abcObject, mesh);
 
                 m_meshSrc = target.sharedMesh;
@@ -734,14 +787,33 @@ namespace UnityEngine.Formats.Alembic.Util
 
 
         #region properties
-        public AlembicRecorderSettings settings
+        /// <summary>
+        /// The Recorder settings.
+        /// </summary>
+        public AlembicRecorderSettings Settings
         {
             get { return m_settings; }
             set { m_settings = value; }
         }
-        public GameObject targetBranch { get { return m_settings.TargetBranch; } set { m_settings.TargetBranch = value; } }
-        public bool recording { get { return m_recording; } }
-        public int frameCount { get { return m_frameCount; } }
+        
+        /// <summary>
+        /// The recording target branch. Ignored if scope is set to whole scene.
+        /// </summary>
+        public GameObject TargetBranch { get { return m_settings.TargetBranch; } set { m_settings.TargetBranch = value; } }
+        
+        /// <summary>
+        /// Returns true if a recording session is active.
+        /// </summary>
+        public bool Recording { get { return m_recording; } }
+        
+        /// <summary>
+        /// Set the frame to stop capturing at. 
+        /// </summary>
+        public int FrameCount
+        {
+            get { return m_frameCount; }
+            set { m_frameCount = value; }
+        }
         #endregion
 
 
@@ -771,9 +843,9 @@ namespace UnityEngine.Formats.Alembic.Util
 
         T[] GetTargets<T>() where T : Component
         {
-            if (m_settings.Scope == ExportScope.TargetBranch && targetBranch != null)
+            if (m_settings.Scope == ExportScope.TargetBranch && TargetBranch != null)
             {
-                return targetBranch.GetComponentsInChildren<T>();
+                return TargetBranch.GetComponentsInChildren<T>();
             }
             else
             {
@@ -783,8 +855,8 @@ namespace UnityEngine.Formats.Alembic.Util
 
         Component[] GetTargets(Type type)
         {
-            if (m_settings.Scope == ExportScope.TargetBranch && targetBranch != null)
-                return targetBranch.GetComponentsInChildren(type);
+            if (m_settings.Scope == ExportScope.TargetBranch && TargetBranch != null)
+                return TargetBranch.GetComponentsInChildren(type);
             else
                 return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsOfType(type), e => (Component)e);
         }
@@ -899,11 +971,18 @@ namespace UnityEngine.Formats.Alembic.Util
 
 
         #region public methods
+        /// <summary>
+        /// Deallocate the native resources.
+        /// </summary>
         public void Dispose()
         {
             m_ctx.Destroy();
         }
 
+        /// <summary>
+        /// Starts a recording session.
+        /// </summary>
+        /// <returns>True if succeeded, false otherwise. </returns>
         public bool BeginRecording()
         {
             if (m_recording)
@@ -911,7 +990,7 @@ namespace UnityEngine.Formats.Alembic.Util
                 Debug.LogWarning("AlembicRecorder: already recording");
                 return false;
             }
-            if (m_settings.Scope == ExportScope.TargetBranch && targetBranch == null)
+            if (m_settings.Scope == ExportScope.TargetBranch && TargetBranch == null)
             {
                 Debug.LogWarning("AlembicRecorder: target object is not set");
                 return false;
@@ -942,7 +1021,7 @@ namespace UnityEngine.Formats.Alembic.Util
                 return false;
             }
 
-            m_ctx.SetConfig(m_settings.conf);
+            m_ctx.SetConfig(m_settings.exportOptions);
             if (!m_ctx.OpenArchive(m_settings.OutputPath))
             {
                 Debug.LogWarning("AlembicRecorder: failed to open file " + m_settings.OutputPath);
@@ -964,13 +1043,16 @@ namespace UnityEngine.Formats.Alembic.Util
             m_time = m_timePrev = 0.0f;
             m_frameCount = 0;
 
-            if (m_settings.conf.TimeSamplingType == aeTimeSamplingType.Uniform && m_settings.FixDeltaTime)
-                Time.maximumDeltaTime = (1.0f / m_settings.conf.FrameRate);
+            if (m_settings.exportOptions.TimeSamplingType == TimeSamplingType.Uniform && m_settings.FixDeltaTime)
+                Time.maximumDeltaTime = (1.0f / m_settings.exportOptions.FrameRate);
 
             Debug.Log("AlembicRecorder: start " + m_settings.OutputPath);
             return true;
         }
 
+        /// <summary>
+        /// Ends the recording session.
+        /// </summary>
         public void EndRecording()
         {
             if (!m_recording) { return; }
@@ -985,7 +1067,7 @@ namespace UnityEngine.Formats.Alembic.Util
             Debug.Log("AlembicRecorder: end: " + m_settings.OutputPath);
         }
 
-        public void ProcessRecording()
+        internal void ProcessRecording()
         {
             if (!m_recording) { return; }
 
@@ -1026,19 +1108,19 @@ namespace UnityEngine.Formats.Alembic.Util
             // advance time
             ++m_frameCount;
             m_timePrev = m_time;
-            switch (m_settings.conf.TimeSamplingType)
+            switch (m_settings.exportOptions.TimeSamplingType)
             {
-                case aeTimeSamplingType.Uniform:
-                    m_time = (1.0f / m_settings.conf.FrameRate) * m_frameCount;
+                case TimeSamplingType.Uniform:
+                    m_time = (1.0f / m_settings.exportOptions.FrameRate) * m_frameCount;
                     break;
-                case aeTimeSamplingType.Acyclic:
+                case TimeSamplingType.Acyclic:
                     m_time += Time.deltaTime;
                     break;
             }
             m_elapsed = Time.realtimeSinceStartup - begin_time;
 
             // wait maximumDeltaTime if timeSamplingType is uniform
-            if (m_settings.conf.TimeSamplingType == aeTimeSamplingType.Uniform && m_settings.FixDeltaTime)
+            if (m_settings.exportOptions.TimeSamplingType == TimeSamplingType.Uniform && m_settings.FixDeltaTime)
                 AbcAPI.aeWaitMaxDeltaTime();
 
             if (m_settings.DetailedLog)

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -11,7 +11,7 @@ using UnityEngine.Formats.Alembic.Sdk;
 
 namespace UnityEngine.Formats.Alembic.Util
 {
-    internal enum ExportScope
+    public enum ExportScope
     {
         EntireScene,
         TargetBranch,
@@ -19,7 +19,7 @@ namespace UnityEngine.Formats.Alembic.Util
 
 
     [Serializable]
-    internal class AlembicRecorderSettings
+    public class AlembicRecorderSettings
     {
         [SerializeField]
         private string outputPath = "Output/Output.abc";
@@ -180,10 +180,10 @@ namespace UnityEngine.Formats.Alembic.Util
 
 
     [Serializable]
-    sealed class AlembicRecorder : IDisposable
+    public sealed class AlembicRecorder : IDisposable
     {
         #region internal types
-        public class MeshBuffer : IDisposable
+        class MeshBuffer : IDisposable
         {
             public bool visibility = true;
             public PinnedList<Vector3> points = new PinnedList<Vector3>();
@@ -302,7 +302,7 @@ namespace UnityEngine.Formats.Alembic.Util
             }
         }
 
-        public class ClothBuffer : IDisposable
+        class ClothBuffer : IDisposable
         {
             public PinnedList<int> remap = new PinnedList<int>();
             public PinnedList<Vector3> vertices = new PinnedList<Vector3>();

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -25,7 +25,7 @@ namespace UnityEngine.Formats.Alembic.Util
         /// </summary>
         TargetBranch,
     }
-    
+
     /// <summary>
     /// Settings controlling different aspects of recording.
     /// </summary>
@@ -49,7 +49,7 @@ namespace UnityEngine.Formats.Alembic.Util
         /// <summary>
         /// Alembic file options (archive type, transform format, etc)
         /// </summary>
-        public AlembicExportOptions exportOptions => conf;
+        public AlembicExportOptions ExportOptions => conf;
 
         [SerializeField]
         ExportScope scope = ExportScope.EntireScene;
@@ -73,7 +73,7 @@ namespace UnityEngine.Formats.Alembic.Util
             set { targetBranch = value; }
         }
 
-        [SerializeField]
+        [SerializeField, HideInInspector]
         bool fixDeltaTime = true;
         /// <summary>
         /// Enable this option to set Time.maximumDeltaTime using the frame rate to ensure fixed delta time.
@@ -795,19 +795,19 @@ namespace UnityEngine.Formats.Alembic.Util
             get { return m_settings; }
             set { m_settings = value; }
         }
-        
+
         /// <summary>
         /// The recording target branch. Ignored if scope is set to whole scene.
         /// </summary>
         public GameObject TargetBranch { get { return m_settings.TargetBranch; } set { m_settings.TargetBranch = value; } }
-        
+
         /// <summary>
         /// Returns true if a recording session is active.
         /// </summary>
         public bool Recording { get { return m_recording; } }
-        
+
         /// <summary>
-        /// Set the frame to stop capturing at. 
+        /// Set the frame to stop capturing at.
         /// </summary>
         public int FrameCount
         {
@@ -1021,7 +1021,7 @@ namespace UnityEngine.Formats.Alembic.Util
                 return false;
             }
 
-            m_ctx.SetConfig(m_settings.exportOptions);
+            m_ctx.SetConfig(m_settings.ExportOptions);
             if (!m_ctx.OpenArchive(m_settings.OutputPath))
             {
                 Debug.LogWarning("AlembicRecorder: failed to open file " + m_settings.OutputPath);
@@ -1043,8 +1043,8 @@ namespace UnityEngine.Formats.Alembic.Util
             m_time = m_timePrev = 0.0f;
             m_frameCount = 0;
 
-            if (m_settings.exportOptions.TimeSamplingType == TimeSamplingType.Uniform && m_settings.FixDeltaTime)
-                Time.maximumDeltaTime = (1.0f / m_settings.exportOptions.FrameRate);
+            if (m_settings.ExportOptions.TimeSamplingType == TimeSamplingType.Uniform && m_settings.FixDeltaTime)
+                Time.maximumDeltaTime = (1.0f / m_settings.ExportOptions.FrameRate);
 
             Debug.Log("AlembicRecorder: start " + m_settings.OutputPath);
             return true;
@@ -1067,7 +1067,11 @@ namespace UnityEngine.Formats.Alembic.Util
             Debug.Log("AlembicRecorder: end: " + m_settings.OutputPath);
         }
 
-        internal void ProcessRecording()
+        /// <summary>
+        /// Writes the current frame to the alembic archive. Recording should have been started previoiusly.
+        /// </summary>
+
+        public void ProcessRecording()
         {
             if (!m_recording) { return; }
 
@@ -1108,10 +1112,10 @@ namespace UnityEngine.Formats.Alembic.Util
             // advance time
             ++m_frameCount;
             m_timePrev = m_time;
-            switch (m_settings.exportOptions.TimeSamplingType)
+            switch (m_settings.ExportOptions.TimeSamplingType)
             {
                 case TimeSamplingType.Uniform:
-                    m_time = (1.0f / m_settings.exportOptions.FrameRate) * m_frameCount;
+                    m_time = (1.0f / m_settings.ExportOptions.FrameRate) * m_frameCount;
                     break;
                 case TimeSamplingType.Acyclic:
                     m_time += Time.deltaTime;
@@ -1120,7 +1124,7 @@ namespace UnityEngine.Formats.Alembic.Util
             m_elapsed = Time.realtimeSinceStartup - begin_time;
 
             // wait maximumDeltaTime if timeSamplingType is uniform
-            if (m_settings.exportOptions.TimeSamplingType == TimeSamplingType.Uniform && m_settings.FixDeltaTime)
+            if (m_settings.ExportOptions.TimeSamplingType == TimeSamplingType.Uniform && m_settings.FixDeltaTime)
                 AbcAPI.aeWaitMaxDeltaTime();
 
             if (m_settings.DetailedLog)

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -799,7 +799,11 @@ namespace UnityEngine.Formats.Alembic.Util
         /// <summary>
         /// The recording target branch. Ignored if scope is set to whole scene.
         /// </summary>
-        public GameObject TargetBranch { get { return m_settings.TargetBranch; } set { m_settings.TargetBranch = value; } }
+        public GameObject TargetBranch
+        {
+            get { return m_settings.TargetBranch; }
+            set { m_settings.TargetBranch = value; }
+        }
 
         /// <summary>
         /// Returns true if a recording session is active.

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -41,13 +41,6 @@ namespace UnityEngine.Formats.Alembic.Sdk
         Quads,
     };
 
-    internal enum aiTimeSamplingType
-    {
-        Uniform,
-        Cyclic,
-        Acyclic,
-    };
-
     internal enum aiPropertyType
     {
         Unknown,

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace UnityEngine.Formats.Alembic.Sdk
 {
-    public enum AspectRatioMode
+    enum AspectRatioMode
     {
         CurrentResolution,
         DefaultResolution,
@@ -15,14 +15,26 @@ namespace UnityEngine.Formats.Alembic.Sdk
     public enum NormalsMode
     {
         //Import,
+        /// <summary>
+        /// If Alembic file has no normals, compute them
+        /// </summary>
         CalculateIfMissing = 1,
+        /// <summary>
+        /// Ignore normals from the Alembic file and always recompute.
+        /// </summary>
         AlwaysCalculate = 2,
         //None
     }
 
     public enum TangentsMode
     {
+        /// <summary>
+        /// Do not compute tangents.
+        /// </summary>
         None,
+        /// <summary>
+        /// Compute and set mesh tangents. Needs normals and UVs.
+        /// </summary>
         Calculate,
     }
 
@@ -78,7 +90,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public NormalsMode normalsMode { get; set; }
         public TangentsMode tangentsMode { get; set; }
         public float scaleFactor { get; set; }
-        public float aspectRatio { get; set; }
+        public float aspectRatio { get; set; } // Broken
         public float vertexMotionScale { get; set; }
         public int splitUnit { get; set; }
         public Bool swapHandedness { get; set; }
@@ -309,7 +321,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         internal aiObject topObject { get { return NativeMethods.aiContextGetTopObject(self); } }
         public int timeSamplingCount { get { return NativeMethods.aiContextGetTimeSamplingCount(self); } }
         public aiTimeSampling GetTimeSampling(int i) { return NativeMethods.aiContextGetTimeSampling(self, i); }
-        internal void GetTimeRange(ref double begin, ref double end) { NativeMethods.aiContextGetTimeRange(self, ref begin, ref end); }
+        internal void GetTimeRange(out double begin, out double end) { NativeMethods.aiContextGetTimeRange(self, out begin, out end); }
     }
 
     struct aiTimeSampling

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -5,35 +5,35 @@ using UnityEngine;
 
 namespace UnityEngine.Formats.Alembic.Sdk
 {
-    internal enum aiAspectRatioMode
+    public enum AspectRatioMode
     {
         CurrentResolution,
         DefaultResolution,
         CameraAperture
     };
 
-    internal enum aiNormalsMode
+    public enum NormalsMode
     {
-        Import,
-        CalculateIfMissing,
-        AlwaysCalculate,
-        None
+        //Import,
+        CalculateIfMissing = 1,
+        AlwaysCalculate = 2,
+        //None
     }
 
-    internal enum aiTangentsMode
+    public enum TangentsMode
     {
         None,
         Calculate,
     }
 
-    internal enum aiTopologyVariance
+    enum aiTopologyVariance
     {
         Constant,
         Homogeneous, // vertices are variant, topology is constant
         Heterogeneous, // both vertices and topology are variant
     }
 
-    internal enum aiTopology
+    enum aiTopology
     {
         Points,
         Lines,
@@ -41,7 +41,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         Quads,
     };
 
-    internal enum aiPropertyType
+    enum aiPropertyType
     {
         Unknown,
 
@@ -73,10 +73,10 @@ namespace UnityEngine.Formats.Alembic.Sdk
     };
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct aiConfig
+    struct aiConfig
     {
-        public aiNormalsMode normalsMode { get; set; }
-        public aiTangentsMode tangentsMode { get; set; }
+        public NormalsMode normalsMode { get; set; }
+        public TangentsMode tangentsMode { get; set; }
         public float scaleFactor { get; set; }
         public float aspectRatio { get; set; }
         public float vertexMotionScale { get; set; }
@@ -91,8 +91,8 @@ namespace UnityEngine.Formats.Alembic.Sdk
 
         public void SetDefaults()
         {
-            normalsMode = aiNormalsMode.CalculateIfMissing;
-            tangentsMode = aiTangentsMode.None;
+            normalsMode = NormalsMode.CalculateIfMissing;
+            tangentsMode = TangentsMode.None;
             scaleFactor = 0.01f;
             aspectRatio = -1.0f;
             vertexMotionScale = 1.0f;
@@ -111,7 +111,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         }
     }
 
-    internal struct aiSampleSelector
+    struct aiSampleSelector
     {
         public ulong requestedIndex { get; set; }
         public double requestedTime { get; set; }
@@ -119,7 +119,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct aiMeshSummary
+    struct aiMeshSummary
     {
         public aiTopologyVariance topologyVariance { get; set; }
         public Bool hasCounts { get; set; }
@@ -214,13 +214,13 @@ namespace UnityEngine.Formats.Alembic.Sdk
         }
     }
 
-    internal struct aiSubmeshData
+    struct aiSubmeshData
     {
         public IntPtr indexes;
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct aiXformData
+    struct aiXformData
     {
         public Bool visibility { get; set; }
 
@@ -232,7 +232,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
 
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct aiPointsSummary
+    struct aiPointsSummary
     {
         public Bool hasVelocities { get; set; }
         public Bool hasIDs { get; set; }
@@ -241,13 +241,13 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public Bool constantIDs { get; set; }
     };
 
-    internal struct aiPointsSampleSummary
+    struct aiPointsSampleSummary
     {
         public int count { get; set; }
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct aiPointsData
+    struct aiPointsData
     {
         public Bool visibility;
 
@@ -258,34 +258,14 @@ namespace UnityEngine.Formats.Alembic.Sdk
 
         public Vector3 boundsCenter;
         public Vector3 boundsExtents;
-
-        public aiPointsData(
-            Bool visibility, IntPtr points, IntPtr velocities, IntPtr ids,
-            int count, Vector3 boundsCenter, Vector3 boundsExtents)
-        {
-            this.visibility = visibility;
-            this.points = points;
-            this.velocities = velocities;
-            this.ids = ids;
-            this.count = count;
-            this.boundsCenter = boundsCenter;
-            this.boundsExtents = boundsExtents;
-        }
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct aiPropertyData
+    struct aiPropertyData
     {
         public IntPtr data;
         public int size;
         public aiPropertyType type;
-
-        public aiPropertyData(IntPtr data, int size, aiPropertyType type)
-        {
-            this.data = data;
-            this.size = size;
-            this.type = type;
-        }
     }
 
     internal static class Abci
@@ -301,7 +281,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
 #endif
     }
 
-    internal struct aiContext
+    struct aiContext
     {
         internal IntPtr self;
         public static implicit operator bool(aiContext v) { return v.self != IntPtr.Zero; }
@@ -332,32 +312,18 @@ namespace UnityEngine.Formats.Alembic.Sdk
         internal void GetTimeRange(ref double begin, ref double end) { NativeMethods.aiContextGetTimeRange(self, ref begin, ref end); }
     }
 
-    internal struct aiTimeSampling
+    struct aiTimeSampling
     {
         internal IntPtr self;
-
-        internal aiTimeSampling(IntPtr self)
-        {
-            this.self = self;
-        }
 
         public int sampleCount { get { return NativeMethods.aiTimeSamplingGetSampleCount(self); } }
         public double GetTime(int index) { return NativeMethods.aiTimeSamplingGetTime(self, index); }
-        internal void GetRange(ref double start, ref double end) { NativeMethods.aiTimeSamplingGetRange(self, ref start, ref end); }
     }
 
-    internal struct aiObject
+    struct aiObject
     {
         internal IntPtr self;
-
-        internal aiObject(IntPtr self)
-        {
-            this.self = self;
-        }
-
         public static implicit operator bool(aiObject v) { return v.self != IntPtr.Zero; }
-        public static bool ToBool(aiObject v) { return v; }
-
         public aiContext context { get { return NativeMethods.aiObjectGetContext(self); } }
         public string name { get { return Marshal.PtrToStringAnsi(NativeMethods.aiObjectGetName(self)); } }
         public string fullname { get { return Marshal.PtrToStringAnsi(NativeMethods.aiObjectGetFullName(self)); } }
@@ -384,30 +350,21 @@ namespace UnityEngine.Formats.Alembic.Sdk
         }
     }
 
-    internal struct aiSchema
+    struct aiSchema
     {
         public IntPtr self;
-
-        public aiSchema(IntPtr self)
-        {
-            this.self = self;
-        }
 
         public static implicit operator bool(aiSchema v) { return v.self != IntPtr.Zero; }
         public static explicit operator aiXform(aiSchema v) { var tmp = default(aiXform); tmp.self = v.self; return tmp; }
         public static explicit operator aiCamera(aiSchema v) { var tmp = default(aiCamera); tmp.self = v.self; return tmp; }
         public static explicit operator aiPolyMesh(aiSchema v) { var tmp = default(aiPolyMesh); tmp.self = v.self; return tmp; }
         public static explicit operator aiPoints(aiSchema v) { var tmp = default(aiPoints); tmp.self = v.self; return tmp; }
-
-        public bool isConstant { get { return NativeMethods.aiSchemaIsConstant(self); } }
         public bool isDataUpdated { get { NativeMethods.aiSchemaSync(self); return NativeMethods.aiSchemaIsDataUpdated(self); } }
-        internal aiSample sample { get { return NativeMethods.aiSchemaGetSample(self); } }
-
         public void UpdateSample(ref aiSampleSelector ss) { NativeMethods.aiSchemaUpdateSample(self, ref ss); }
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    internal struct aiXform
+    struct aiXform
     {
         [FieldOffset(0)] public IntPtr self;
         [FieldOffset(0)] public aiSchema schema;
@@ -418,7 +375,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    internal struct aiCamera
+    struct aiCamera
     {
         [FieldOffset(0)] public IntPtr self;
         [FieldOffset(0)] public aiSchema schema;
@@ -429,7 +386,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    internal struct aiPolyMesh
+    struct aiPolyMesh
     {
         [FieldOffset(0)] public IntPtr self;
         [FieldOffset(0)] public aiSchema schema;
@@ -441,7 +398,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    internal struct aiPoints
+    struct aiPoints
     {
         [FieldOffset(0)] public IntPtr self;
         [FieldOffset(0)] public aiSchema schema;
@@ -455,8 +412,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public void GetSummary(ref aiPointsSummary dst) { NativeMethods.aiPointsGetSummary(self, ref dst); }
     }
 
-
-    internal struct aiSample
+    struct aiSample
     {
         public IntPtr self;
         public static implicit operator bool(aiSample v) { return v.self != IntPtr.Zero; }
@@ -466,7 +422,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public static explicit operator aiPointsSample(aiSample v) { aiPointsSample tmp; tmp.self = v.self; return tmp; }
     }
 
-    internal struct aiXformSample
+    struct aiXformSample
     {
         public IntPtr self;
         public static implicit operator bool(aiXformSample v) { return v.self != IntPtr.Zero; }
@@ -475,7 +431,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public void GetData(ref aiXformData dst) { NativeMethods.aiXformGetData(self, ref dst); }
     }
 
-    internal struct aiCameraSample
+    struct aiCameraSample
     {
         public IntPtr self;
         public static implicit operator bool(aiCameraSample v) { return v.self != IntPtr.Zero; }
@@ -484,7 +440,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public void GetData(ref CameraData dst) { NativeMethods.aiCameraGetData(self, ref dst); }
     }
 
-    internal struct aiPolyMeshSample
+    struct aiPolyMeshSample
     {
         public IntPtr self;
         public static implicit operator bool(aiPolyMeshSample v) { return v.self != IntPtr.Zero; }
@@ -497,7 +453,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public void Sync() { NativeMethods.aiSampleSync(self); }
     }
 
-    internal struct aiPointsSample
+    struct aiPointsSample
     {
         public IntPtr self;
         public static implicit operator bool(aiPointsSample v) { return v.self != IntPtr.Zero; }
@@ -509,16 +465,9 @@ namespace UnityEngine.Formats.Alembic.Sdk
     }
 
 
-    internal struct aiProperty
+    struct aiProperty
     {
         public IntPtr self;
-
-        public aiProperty(IntPtr self)
-        {
-            this.self = self;
-        }
-
         public static implicit operator bool(aiProperty v) { return v.self != IntPtr.Zero; }
-        public static bool ToBool(aiProperty v) { return v; }
     }
 }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -90,7 +90,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public NormalsMode normalsMode { get; set; }
         public TangentsMode tangentsMode { get; set; }
         public float scaleFactor { get; set; }
-        public float aspectRatio { get; set; } // Broken
+        public float aspectRatio { get; set; } // Broken/Unimplemented , not connected to any code path.
         public float vertexMotionScale { get; set; }
         public int splitUnit { get; set; }
         public Bool swapHandedness { get; set; }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPoints.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPoints.cs
@@ -86,8 +86,8 @@ namespace UnityEngine.Formats.Alembic.Importer
                 abcTreeNode.gameObject.SetActive(data.visibility);
 
             var cloud = abcTreeNode.gameObject.GetComponent<AlembicPointsCloud>();
-            cloud.boundsCenter = data.boundsCenter;
-            cloud.boundsExtents = data.boundsExtents;
+            cloud.BoundsCenter = data.boundsCenter;
+            cloud.BoundsExtents = data.boundsExtents;
         }
     }
 }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPoints.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPoints.cs
@@ -53,17 +53,17 @@ namespace UnityEngine.Formats.Alembic.Importer
 
             // setup buffers
             var data = default(aiPointsData);
-            cloud.m_points.ResizeDiscard(m_sampleSummary.count);
-            data.points = cloud.m_points;
+            cloud.pointsList.ResizeDiscard(m_sampleSummary.count);
+            data.points = cloud.pointsList;
             if (m_summary.hasVelocities)
             {
-                cloud.m_velocities.ResizeDiscard(m_sampleSummary.count);
-                data.velocities = cloud.m_velocities;
+                cloud.velocitiesList.ResizeDiscard(m_sampleSummary.count);
+                data.velocities = cloud.velocitiesList;
             }
             if (m_summary.hasIDs)
             {
-                cloud.m_ids.ResizeDiscard(m_sampleSummary.count);
-                data.ids = cloud.m_ids;
+                cloud.idsList.ResizeDiscard(m_sampleSummary.count);
+                data.ids = cloud.idsList;
             }
             m_abcData[0] = data;
 
@@ -86,8 +86,8 @@ namespace UnityEngine.Formats.Alembic.Importer
                 abcTreeNode.gameObject.SetActive(data.visibility);
 
             var cloud = abcTreeNode.gameObject.GetComponent<AlembicPointsCloud>();
-            cloud.m_boundsCenter = data.boundsCenter;
-            cloud.m_boundsExtents = data.boundsExtents;
+            cloud.boundsCenter = data.boundsCenter;
+            cloud.boundsExtents = data.boundsExtents;
         }
     }
 }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPointsCloud.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPointsCloud.cs
@@ -29,24 +29,24 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// <summary>
         /// The list of point cloud positions.
         /// </summary>
-        public List<Vector3> positions => pointsList.List;
+        public List<Vector3> Positions => pointsList.List;
         /// <summary>
-        /// The list of point cloud velocities.
+        /// The list of point cloud Velocities.
         /// </summary>
-        public List<Vector3> velocities => velocitiesList.List;
+        public List<Vector3> Velocities => velocitiesList.List;
         /// <summary>
         /// The list of point cloud identifiers.
         /// </summary>
-        public List<uint> ids => idsList.List;
+        public List<uint> Ids => idsList.List;
 
         /// <summary>
         /// The center of the point cloud bounding box
         /// </summary>
-        public Vector3 boundsCenter { get; internal set; }
+        public Vector3 BoundsCenter { get; internal set; }
         /// <summary>
         /// The extent of the point cloud bounding box
         /// </summary>
-        public Vector3 boundsExtents { get; internal set; }
+        public Vector3 BoundsExtents { get; internal set; }
 
         void Reset()
         {

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPointsCloud.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPointsCloud.cs
@@ -1,32 +1,52 @@
-using UnityEngine;
+using System.Collections.Generic;
 using UnityEngine.Formats.Alembic.Sdk;
 
 
 namespace UnityEngine.Formats.Alembic.Importer
 {
+    /// <summary>
+    /// This class is the scene data container for animated point clouds.
+    /// </summary>
     [ExecuteInEditMode]
-    internal class AlembicPointsCloud : MonoBehaviour
+    public class AlembicPointsCloud : MonoBehaviour
     {
         // members
-        [ReadOnly] public PinnedList<Vector3> m_points = new PinnedList<Vector3>();
-        [ReadOnly] public PinnedList<Vector3> m_velocities = new PinnedList<Vector3>();
-        [ReadOnly] public PinnedList<uint> m_ids = new PinnedList<uint>();
-
-        [ReadOnly] public Vector3 m_boundsCenter;
-        [ReadOnly] public Vector3 m_boundsExtents;
+        PinnedList<Vector3> m_points = new PinnedList<Vector3>();
+        PinnedList<Vector3> m_velocities = new PinnedList<Vector3>();
+        PinnedList<uint> m_ids = new PinnedList<uint>();
 
         internal AlembicPoints m_abc = null;
 
         [Tooltip("Sort points by distance from sortFrom object")]
-        public bool m_sort = false;
-        public Transform m_sortFrom;
+        internal bool m_sort = false;
+        internal Transform m_sortFrom;
 
         // properties
-        internal AlembicPoints abcPoints { get { return m_abc; } }
-        public PinnedList<Vector3> points { get { return m_points; } }
-        public PinnedList<Vector3> velocities { get { return m_velocities; } }
-        public PinnedList<uint> ids { get { return m_ids; } }
+        internal PinnedList<Vector3> pointsList { get { return m_points; } }
+        internal PinnedList<Vector3> velocitiesList { get { return m_velocities; } }
+        internal PinnedList<uint> idsList { get { return m_ids; } }
 
+        /// <summary>
+        /// The list of point cloud positions.
+        /// </summary>
+        public List<Vector3> positions => pointsList.List;
+        /// <summary>
+        /// The list of point cloud velocities.
+        /// </summary>
+        public List<Vector3> velocities => velocitiesList.List;
+        /// <summary>
+        /// The list of point cloud identifiers.
+        /// </summary>
+        public List<uint> ids => idsList.List;
+
+        /// <summary>
+        /// The center of the point cloud bounding box
+        /// </summary>
+        public Vector3 boundsCenter { get; internal set; }
+        /// <summary>
+        /// The extent of the point cloud bounding box
+        /// </summary>
+        public Vector3 boundsExtents { get; internal set; }
 
         void Reset()
         {

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPointsRenderer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPointsRenderer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 #if UNITY_EDITOR
@@ -101,7 +100,15 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// </summary>
         public List<Material> Materials
         {
-            get { return m_materials.ToList(); }
+            get
+            {
+                var ret = new List<Material>(m_materials.Length);
+                foreach (var t in m_materials)
+                {
+                    ret[0] = t;
+                }
+                return ret;
+            }
             set { m_materials = value.ToArray(); }
         }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPointsRenderer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPointsRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 #if UNITY_EDITOR
@@ -86,16 +87,28 @@ namespace UnityEngine.Formats.Alembic.Importer
         Vector3 m_scale, m_scaleOld;
 
 
-        public Mesh sharedMesh
+        /// <summary>
+        /// The mesh to be instanced for every point cloud.
+        /// </summary>
+        public Mesh InstancedMesh
         {
             get { return m_mesh; }
             set { m_mesh = value; }
         }
 
-        public Material[] GetSharedMaterials() { return m_materials; }
-        public void SetSharedMaterials(Material[] value) { m_materials = value; }
+        /// <summary>
+        /// An array of materials used for the rendering the instanced mesh. Only one material per sub-mesh will be used.
+        /// </summary>
+        public List<Material> Materials
+        {
+            get { return m_materials.ToList(); }
+            set { m_materials = value.ToArray(); }
+        }
 
-        public Material motionVectorMaterial
+        /// <summary>
+        /// Material to be used for the motion vector computation.
+        /// </summary>
+        public Material MotionVectorMaterial
         {
             get { return m_motionVectorMaterial; }
             set { m_motionVectorMaterial = value; }
@@ -106,11 +119,11 @@ namespace UnityEngine.Formats.Alembic.Importer
         {
             var apc = GetComponent<AlembicPointsCloud>();
 
-            var points = apc.positions;
+            var points = apc.Positions;
             int numInstances = points.Count;
             if (numInstances == 0) { return; }
-            var velocities = apc.velocities;
-            var ids = apc.ids;
+            var velocities = apc.Velocities;
+            var ids = apc.Ids;
 
             var materials = m_materials;
             var mesh = m_mesh;
@@ -188,7 +201,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             }
 
             // build bounds
-            m_bounds = new Bounds(apc.boundsCenter, apc.boundsExtents + mesh.bounds.extents);
+            m_bounds = new Bounds(apc.BoundsCenter, apc.BoundsExtents + mesh.bounds.extents);
 
 
             // update materials
@@ -269,7 +282,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             var material = m_motionVectorMaterial;
             var mesh = m_mesh;
             var apc = GetComponent<AlembicPointsCloud>();
-            if (mesh == null || material == null || apc.velocities.Count == 0)
+            if (mesh == null || material == null || apc.Velocities.Count == 0)
                 return;
 
             material.SetMatrix("_PreviousVP", VPMatrices.GetPrevious(Camera.current));

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicSettings.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicSettings.cs
@@ -4,27 +4,27 @@ using UnityEngine.Formats.Alembic.Sdk;
 namespace UnityEngine.Formats.Alembic.Importer
 {
     [System.Serializable]
-    internal class AlembicStreamSettings
+    public class AlembicStreamSettings
     {
         [SerializeField]
-        private aiNormalsMode normals = aiNormalsMode.CalculateIfMissing;
-        public aiNormalsMode Normals
+        private NormalsMode normals = NormalsMode.CalculateIfMissing;
+        public NormalsMode Normals
         {
             get { return normals; }
             set { normals = value; }
         }
 
         [SerializeField]
-        private aiTangentsMode tangents = aiTangentsMode.Calculate;
-        public aiTangentsMode Tangents
+        private TangentsMode tangents = TangentsMode.Calculate;
+        public TangentsMode Tangents
         {
             get { return tangents; }
             set { tangents = value; }
         }
 
         [SerializeField]
-        private aiAspectRatioMode cameraAspectRatio = aiAspectRatioMode.CameraAperture;
-        public aiAspectRatioMode CameraAspectRatio
+        private AspectRatioMode cameraAspectRatio = AspectRatioMode.CameraAperture;
+        public AspectRatioMode CameraAspectRatio
         {
             get { return cameraAspectRatio; }
             set { cameraAspectRatio = value; }
@@ -72,7 +72,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         private bool importPointPolygon = true;
-        public bool ImportPointPolygon
+        internal bool ImportPointPolygon // Broken
         {
             get { return importPointPolygon; }
             set { importPointPolygon = value; }
@@ -80,7 +80,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         private bool importLinePolygon = true;
-        public bool ImportLinePolygon
+        internal bool ImportLinePolygon // Broken
         {
             get { return importLinePolygon; }
             set { importLinePolygon = value; }
@@ -88,7 +88,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         private bool importTrianglePolygon = true;
-        public bool ImportTrianglePolygon
+        internal bool ImportTrianglePolygon // Broken
         {
             get { return importTrianglePolygon; }
             set { importTrianglePolygon = value; }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicSettings.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicSettings.cs
@@ -1,13 +1,18 @@
-using UnityEngine;
 using UnityEngine.Formats.Alembic.Sdk;
 
 namespace UnityEngine.Formats.Alembic.Importer
 {
+    /// <summary>
+    /// This class contains stream reading options.
+    /// </summary>
     [System.Serializable]
     public class AlembicStreamSettings
     {
         [SerializeField]
-        private NormalsMode normals = NormalsMode.CalculateIfMissing;
+        NormalsMode normals = NormalsMode.CalculateIfMissing;
+        /// <summary>
+        /// Normal computation options.
+        /// </summary>
         public NormalsMode Normals
         {
             get { return normals; }
@@ -15,7 +20,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private TangentsMode tangents = TangentsMode.Calculate;
+        TangentsMode tangents = TangentsMode.Calculate;
+        /// <summary>
+        /// Tangent computation options.
+        /// </summary>
         public TangentsMode Tangents
         {
             get { return tangents; }
@@ -23,15 +31,21 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private AspectRatioMode cameraAspectRatio = AspectRatioMode.CameraAperture;
-        public AspectRatioMode CameraAspectRatio
+        AspectRatioMode cameraAspectRatio = AspectRatioMode.CameraAperture;
+        /// <summary>
+        /// Camera aspect ratio import options.
+        /// </summary>
+        internal AspectRatioMode CameraAspectRatio // Broken
         {
             get { return cameraAspectRatio; }
             set { cameraAspectRatio = value; }
         }
 
         [SerializeField]
-        private bool importVisibility = true;
+        bool importVisibility = true;
+        /// <summary>
+        /// Enables or disables the control of the active state of objects.
+        /// </summary>
         public bool ImportVisibility
         {
             get { return importVisibility; }
@@ -39,7 +53,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private float scaleFactor = 0.01f;
+        float scaleFactor = 0.01f;
+        /// <summary>
+        /// The world scale factor conversion between the Alembic file and unity.
+        /// </summary>
         public float ScaleFactor
         {
             get { return scaleFactor; }
@@ -47,7 +64,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool swapHandedness = true;
+        bool swapHandedness = true;
+        /// <summary>
+        /// Switch the X-axis direction to convert between Left and Right handed coordinate systems.
+        /// </summary>
         public bool SwapHandedness
         {
             get { return swapHandedness; }
@@ -55,7 +75,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool flipFaces = false;
+        bool flipFaces = false;
+        /// <summary>
+        /// Invert the orientations of the polygons.
+        /// </summary>
         public bool FlipFaces
         {
             get { return flipFaces; }
@@ -63,7 +86,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool interpolateSamples = true;
+        bool interpolateSamples = true;
+        /// <summary>
+        /// Linearly interpolate between Alembic samples for which the topology does not change.
+        /// </summary>
         public bool InterpolateSamples
         {
             get { return interpolateSamples; }
@@ -71,7 +97,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool importPointPolygon = true;
+        bool importPointPolygon = true;
         internal bool ImportPointPolygon // Broken
         {
             get { return importPointPolygon; }
@@ -79,7 +105,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool importLinePolygon = true;
+        bool importLinePolygon = true;
         internal bool ImportLinePolygon // Broken
         {
             get { return importLinePolygon; }
@@ -87,7 +113,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool importTrianglePolygon = true;
+        bool importTrianglePolygon = true;
         internal bool ImportTrianglePolygon // Broken
         {
             get { return importTrianglePolygon; }
@@ -95,7 +121,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool importXform = true;
+        bool importXform = true;
+        /// <summary>
+        /// Enables or disable the import of transforms.
+        /// </summary>
         public bool ImportXform
         {
             get { return importXform; }
@@ -103,7 +132,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool importCameras = true;
+        bool importCameras = true;
+        /// <summary>
+        /// Enables or disable the import of cameras.
+        /// </summary>
         public bool ImportCameras
         {
             get { return importCameras; }
@@ -111,7 +143,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool importMeshes = true;
+        bool importMeshes = true;
+        /// <summary>
+        /// Enables or disable the import of meshes.
+        /// </summary>
         public bool ImportMeshes
         {
             get { return importMeshes; }
@@ -119,7 +154,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool importPoints = false;
+        bool importPoints = false;
+        /// <summary>
+        /// Enables or disable the import of points.
+        /// </summary>
         public bool ImportPoints
         {
             get { return importPoints; }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicSettings.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicSettings.cs
@@ -35,7 +35,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// <summary>
         /// Camera aspect ratio import options.
         /// </summary>
-        internal AspectRatioMode CameraAspectRatio // Broken
+        internal AspectRatioMode CameraAspectRatio // Broken/Unimplemented , not connected to any code path.
         {
             get { return cameraAspectRatio; }
             set { cameraAspectRatio = value; }
@@ -98,7 +98,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         bool importPointPolygon = true;
-        internal bool ImportPointPolygon // Broken
+        internal bool ImportPointPolygon // Broken/Unimplemented , not connected to any code path.
         {
             get { return importPointPolygon; }
             set { importPointPolygon = value; }
@@ -106,7 +106,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         bool importLinePolygon = true;
-        internal bool ImportLinePolygon // Broken
+        internal bool ImportLinePolygon // Broken/Unimplemented , not connected to any code path.
         {
             get { return importLinePolygon; }
             set { importLinePolygon = value; }
@@ -114,7 +114,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         bool importTrianglePolygon = true;
-        internal bool ImportTrianglePolygon // Broken
+        internal bool ImportTrianglePolygon // Broken/Unimplemented , not connected to any code path.
         {
             get { return importTrianglePolygon; }
             set { importTrianglePolygon = value; }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -270,13 +270,13 @@ namespace UnityEngine.Formats.Alembic.Importer
             ic.alembicTreeNode = treeNode;
         }
 
-        internal static float GetAspectRatio(aiAspectRatioMode mode)
+        internal static float GetAspectRatio(AspectRatioMode mode)
         {
-            if (mode == aiAspectRatioMode.CameraAperture)
+            if (mode == AspectRatioMode.CameraAperture)
             {
                 return 0.0f;
             }
-            else if (mode == aiAspectRatioMode.CurrentResolution)
+            else if (mode == AspectRatioMode.CurrentResolution)
             {
                 return (float)Screen.width / (float)Screen.height;
             }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -65,7 +65,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         public void SetVertexMotionScale(float value) { m_config.vertexMotionScale = value; }
         public void SetAsyncLoad(bool value) { m_config.asyncLoad = value; }
 
-        public void GetTimeRange(ref double begin, ref double end) { m_context.GetTimeRange(ref begin, ref end); }
+        public void GetTimeRange(out double begin, out double end) { m_context.GetTimeRange(out begin, out end); }
 
 
         internal AlembicStream(GameObject rootGo, AlembicStreamDescriptor streamDesc)
@@ -142,7 +142,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             if (m_loaded)
             {
                 UpdateAbcTree(m_context, m_abcTreeRoot, m_time, createMissingNodes, initialImport);
-                AlembicStream.s_streams.Add(this);
+                s_streams.Add(this);
             }
             else
             {

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -119,7 +119,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             AbcEndSyncData(m_abcTreeRoot);
         }
 
-        public void AbcLoad(bool createMissingNodes, bool initialImport)
+        public bool AbcLoad(bool createMissingNodes, bool initialImport)
         {
             m_time = 0.0f;
             m_context = aiContext.Create(m_abcTreeRoot.gameObject.GetInstanceID());
@@ -148,6 +148,8 @@ namespace UnityEngine.Formats.Alembic.Importer
             {
                 Debug.LogError("failed to load alembic at " + m_streamDesc.PathToAbc);
             }
+
+            return m_loaded;
         }
 
         public void Dispose()

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
@@ -1,9 +1,15 @@
 namespace UnityEngine.Formats.Alembic.Importer
 {
+    /// <summary>
+    /// A class that that stores information about an Alembic stream.
+    /// </summary>
     public class AlembicStreamDescriptor : ScriptableObject
     {
         [SerializeField]
         string pathToAbc;
+        /// <summary>
+        /// The path to the Alembic asset. When in a standalone build, the returned path is prepended by the streamingAssets path.
+        /// </summary>
         public string PathToAbc
         {
             // For standalone builds, the path should be relative to the StreamingAssets
@@ -20,18 +26,40 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         AlembicStreamSettings settings = new AlembicStreamSettings();
+        /// <summary>
+        /// The stream import options.
+        /// </summary>
         public AlembicStreamSettings Settings
         {
-            get { return settings; }
-            set { settings = value; }
+            get => settings;
+            set => settings = value;
+        }
+
+        [SerializeField] float abcStartTime = float.MinValue;
+        /// <summary>
+        /// The start timestamp of the Alembic file.
+        /// </summary>
+        public float mediaStartTime
+        {
+            get => abcStartTime;
+            internal set => abcStartTime = value;
         }
 
         [SerializeField]
-        internal double abcStartTime = double.MinValue;
+        float abcEndTime = float.MaxValue;
 
-        [SerializeField]
-        internal double abcEndTime = double.MaxValue;
+        /// <summary>
+        /// The end timestamp of the Alembic file.
+        /// </summary>
+        public float mediaEndTime
+        {
+            get => abcEndTime;
+            internal set => abcEndTime = value;
+        }
 
-        public double mediaDuration { get { return abcEndTime - abcStartTime; } }
+        /// <summary>
+        /// The duration of the Alembic file.
+        /// </summary>
+        public float mediaDuration => abcEndTime - abcStartTime;
     }
 }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
@@ -1,15 +1,9 @@
 namespace UnityEngine.Formats.Alembic.Importer
 {
-    /// <summary>
-    /// A class that that stores information about an Alembic stream.
-    /// </summary>
-    public class AlembicStreamDescriptor : ScriptableObject
+    class AlembicStreamDescriptor : ScriptableObject
     {
         [SerializeField]
         string pathToAbc;
-        /// <summary>
-        /// The path to the Alembic asset. When in a standalone build, the returned path is prepended by the streamingAssets path.
-        /// </summary>
         public string PathToAbc
         {
             // For standalone builds, the path should be relative to the StreamingAssets
@@ -21,14 +15,11 @@ namespace UnityEngine.Formats.Alembic.Importer
                 return System.IO.Path.Combine(Application.streamingAssetsPath, pathToAbc);
 #endif
             }
-            set { pathToAbc = value; }
+            internal set { pathToAbc = value; }
         }
 
         [SerializeField]
         AlembicStreamSettings settings = new AlembicStreamSettings();
-        /// <summary>
-        /// The stream import options.
-        /// </summary>
         public AlembicStreamSettings Settings
         {
             get => settings;
@@ -36,9 +27,6 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField] float abcStartTime = float.MinValue;
-        /// <summary>
-        /// The start timestamp of the Alembic file.
-        /// </summary>
         public float mediaStartTime
         {
             get => abcStartTime;
@@ -47,19 +35,11 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         float abcEndTime = float.MaxValue;
-
-        /// <summary>
-        /// The end timestamp of the Alembic file.
-        /// </summary>
         public float mediaEndTime
         {
             get => abcEndTime;
             internal set => abcEndTime = value;
         }
-
-        /// <summary>
-        /// The duration of the Alembic file.
-        /// </summary>
         public float mediaDuration => abcEndTime - abcStartTime;
     }
 }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
@@ -1,11 +1,9 @@
-using UnityEngine;
-
 namespace UnityEngine.Formats.Alembic.Importer
 {
-    internal class AlembicStreamDescriptor : ScriptableObject
+    public class AlembicStreamDescriptor : ScriptableObject
     {
         [SerializeField]
-        private string pathToAbc;
+        string pathToAbc;
         public string PathToAbc
         {
             // For standalone builds, the path should be relative to the StreamingAssets
@@ -21,7 +19,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private AlembicStreamSettings settings = new AlembicStreamSettings();
+        AlembicStreamSettings settings = new AlembicStreamSettings();
         public AlembicStreamSettings Settings
         {
             get { return settings; }
@@ -29,19 +27,11 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool hasAcyclicFramerate = false;
-        public bool HasAcyclicFramerate
-        {
-            get { return hasAcyclicFramerate; }
-            set { hasAcyclicFramerate = value; }
-        }
+        internal double abcStartTime = double.MinValue;
 
         [SerializeField]
-        public double abcStartTime = double.MinValue;
+        internal double abcEndTime = double.MaxValue;
 
-        [SerializeField]
-        public double abcEndTime = double.MaxValue;
-
-        public double duration { get { return abcEndTime - abcStartTime; } }
+        public double mediaDuration { get { return abcEndTime - abcStartTime; } }
     }
 }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamDescriptor.cs
@@ -29,14 +29,6 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool hasVaryingTopology = false;
-        public bool HasVaryingTopology
-        {
-            get { return hasVaryingTopology; }
-            set { hasVaryingTopology = value; }
-        }
-
-        [SerializeField]
         private bool hasAcyclicFramerate = false;
         public bool HasAcyclicFramerate
         {

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -13,6 +13,9 @@ namespace UnityEngine.Formats.Alembic.Importer
         AlembicStream abcStream { get; set; }
         [SerializeField]
         AlembicStreamDescriptor streamDescriptor;
+        /// <summary>
+        /// Gives access to the stream description.
+        /// </summary>
         public AlembicStreamDescriptor StreamDescriptor
         {
             get { return streamDescriptor; }
@@ -32,7 +35,7 @@ namespace UnityEngine.Formats.Alembic.Importer
                 startTime = value;
                 if (StreamDescriptor == null)
                     return;
-                startTime = Mathf.Clamp(startTime, (float)StreamDescriptor.abcStartTime, (float)StreamDescriptor.abcEndTime);
+                startTime = Mathf.Clamp(startTime, StreamDescriptor.mediaStartTime, StreamDescriptor.mediaEndTime);
             }
         }
 
@@ -49,7 +52,7 @@ namespace UnityEngine.Formats.Alembic.Importer
                 endTime = value;
                 if (StreamDescriptor == null)
                     return;
-                endTime = Mathf.Clamp(endTime, StartTime, (float)StreamDescriptor.abcEndTime);
+                endTime = Mathf.Clamp(endTime, StartTime, StreamDescriptor.mediaEndTime);
             }
         }
 
@@ -122,10 +125,16 @@ namespace UnityEngine.Formats.Alembic.Importer
         {
             if (StreamDescriptor == null || abcStream == null)
                 return;
-            if (StreamDescriptor.abcStartTime == double.MinValue || StreamDescriptor.abcEndTime == double.MaxValue)
-                abcStream.GetTimeRange(ref StreamDescriptor.abcStartTime, ref StreamDescriptor.abcEndTime);
-            StartTime = Mathf.Clamp(StartTime, (float)StreamDescriptor.abcStartTime, (float)StreamDescriptor.abcEndTime);
-            EndTime = Mathf.Clamp(EndTime, StartTime, (float)StreamDescriptor.abcEndTime);
+            if (StreamDescriptor.mediaStartTime == double.MinValue || StreamDescriptor.mediaEndTime == double.MaxValue)
+            {
+                double start, end;
+                abcStream.GetTimeRange(out start, out end);
+                StreamDescriptor.mediaStartTime = (float)start;
+                StreamDescriptor.mediaEndTime = (float)end;
+            }
+
+            StartTime = Mathf.Clamp(StartTime, StreamDescriptor.mediaStartTime, StreamDescriptor.mediaEndTime);
+            EndTime = Mathf.Clamp(EndTime, StartTime, StreamDescriptor.mediaEndTime);
             ClampTime();
             forceUpdate = true;
         }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -87,21 +87,21 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// <summary>
         /// The start timestamp of the Alembic file.
         /// </summary>
-        public float mediaStartTime => StreamDescriptor ? StreamDescriptor.mediaStartTime : 0;
+        public float MediaStartTime => StreamDescriptor ? StreamDescriptor.mediaStartTime : 0;
         /// <summary>
         /// The end timestamp of the Alembic file.
         /// </summary>
-        public float mediaEndTime => StreamDescriptor ? StreamDescriptor.mediaEndTime : 0;
+        public float MediaEndTime => StreamDescriptor ? StreamDescriptor.mediaEndTime : 0;
 
         /// <summary>
         /// The duration of the Alembic file.
         /// </summary>
-        public float mediaDuration => mediaEndTime - mediaStartTime;
+        public float MediaDuration => MediaEndTime - MediaStartTime;
 
         /// <summary>
         /// The path to the Alembic asset. When in a standalone build, the returned path is prepended by the streamingAssets path.
         /// </summary>
-        public string pathToAbc => StreamDescriptor != null ? StreamDescriptor.PathToAbc : "";
+        public string PathToAbc => StreamDescriptor != null ? StreamDescriptor.PathToAbc : "";
         
         /// <summary>
         /// The stream import options.

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -131,7 +131,8 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// Loads a different alembic file.
         /// </summary>
         /// <param name="newPath">Path to the new file.</param>
-        public void LoadFromFile(string newPath)
+        /// <returns>True if the load succeeded, false otherwise.</returns>
+        public bool LoadFromFile(string newPath)
         {
             if (StreamDescriptor == null)
             {
@@ -139,14 +140,15 @@ namespace UnityEngine.Formats.Alembic.Importer
             }
 
             StreamDescriptor.PathToAbc = newPath;
-            InitializeAfterLoad();
-
+            return InitializeAfterLoad();
         }
 
-        void InitializeAfterLoad()
+        bool InitializeAfterLoad()
         {
-            LoadStream(true);
-            abcStream.AbcLoad(true, true);
+            var ret = LoadStream(true);
+            if (!ret)
+                return false;
+            //abcStream.AbcLoad(true, true);
             double start, end;
             abcStream.GetTimeRange(out start, out end);
             startTime = (float) start;
@@ -170,6 +172,8 @@ namespace UnityEngine.Formats.Alembic.Importer
             {
                 meshFilter.sharedMesh.hideFlags |= HideFlags.DontSave;
             }
+
+            return true;
         }
 
         void ClampTime()
@@ -177,13 +181,14 @@ namespace UnityEngine.Formats.Alembic.Importer
             CurrentTime = Mathf.Clamp(CurrentTime, 0.0f, Duration);
         }
 
-        internal void LoadStream(bool createMissingNodes)
+        internal bool  LoadStream(bool createMissingNodes)
         {
             if (StreamDescriptor == null)
-                return;
+                return false;
             abcStream = new AlembicStream(gameObject, StreamDescriptor);
-            abcStream.AbcLoad(createMissingNodes, false);
+            var ret = abcStream.AbcLoad(createMissingNodes, false);
             forceUpdate = true;
+            return ret;
         }
 
         void Start()

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -13,7 +13,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         AlembicStream abcStream { get; set; }
         [SerializeField]
         AlembicStreamDescriptor streamDescriptor;
-        internal AlembicStreamDescriptor StreamDescriptor
+        public AlembicStreamDescriptor StreamDescriptor
         {
             get { return streamDescriptor; }
             set { streamDescriptor = value; }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -3,6 +3,9 @@ using UnityEngine.Formats.Alembic.Sdk;
 
 namespace UnityEngine.Formats.Alembic.Importer
 {
+    /// <summary>
+    /// This component allows data streaming from alembic files. It updates children nodes (meshes, transforms, cameras, etc) to reflect the alembic data at the given time.
+    /// </summary>
     [ExecuteInEditMode]
     public class AlembicStreamPlayer : MonoBehaviour
     {
@@ -18,6 +21,9 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         float startTime = float.MinValue;
+        /// <summary>
+        /// The beginning of the streaming time window. This is clamped to the time range of the alembic source file.
+        /// </summary>
         public float StartTime
         {
             get { return startTime; }
@@ -32,6 +38,9 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         float endTime = float.MaxValue;
+        /// <summary>
+        /// The end of the streaming time window. This is clamped to the time range of the alembic source file.
+        /// </summary>
         public float EndTime
         {
             get { return endTime; }
@@ -46,14 +55,25 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         float currentTime;
+        /// <summary>
+        /// The time relative to the alembic time range. This is clamped between 0 and the alembic time duration.
+        /// </summary>
         public float CurrentTime
         {
             get { return currentTime; }
             set { currentTime = Mathf.Clamp(value, 0.0f, Duration); }
         }
 
+        /// <summary>
+        /// The duration of the Alembic file.
+        /// </summary>
+        public float Duration { get { return EndTime - StartTime; } }
+
         [SerializeField]
-        private float vertexMotionScale = 1.0f;
+        float vertexMotionScale = 1.0f;
+        /// <summary>
+        /// Scalar multiplier to the Alembic vertex speed. Default value is 1.
+        /// </summary>
         public float VertexMotionScale
         {
             get { return vertexMotionScale; }
@@ -61,18 +81,12 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         [SerializeField]
-        private bool asyncLoad = true;
-        bool AsyncLoad
-        {
-            get { return asyncLoad; }
-            set { asyncLoad = value; }
-        }
+        bool asyncLoad = true;
+        
         float lastUpdateTime;
         bool forceUpdate = false;
         bool updateStarted = false;
-
-        public float Duration { get { return EndTime - StartTime; } }
-
+        
 
         void ClampTime()
         {
@@ -105,6 +119,9 @@ namespace UnityEngine.Formats.Alembic.Importer
             forceUpdate = true;
         }
 
+        /// <summary>
+        /// Update the child game object's data to the CurrentTime.
+        /// </summary>
         public void Update()
         {
             if (abcStream == null || StreamDescriptor == null)
@@ -114,7 +131,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             if (lastUpdateTime != CurrentTime || forceUpdate)
             {
                 abcStream.SetVertexMotionScale(VertexMotionScale);
-                abcStream.SetAsyncLoad(AsyncLoad );
+                abcStream.SetAsyncLoad(asyncLoad);
                 if (abcStream.AbcUpdateBegin(StartTime + CurrentTime))
                 {
                     lastUpdateTime = CurrentTime;

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -82,11 +82,22 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         bool asyncLoad = true;
-        
+
         float lastUpdateTime;
         bool forceUpdate = false;
         bool updateStarted = false;
-        
+
+
+        /// <summary>
+        /// Update the child game object's data to the CurrentTime (The regular update happens during the LateUpdate phase).
+        /// </summary>
+        /// <param name="time">The time stamp to stream from the asset file</param>
+        public void UpdateImmediately(float time)
+        {
+            CurrentTime = time;
+            Update();
+            LateUpdate();
+        }
 
         void ClampTime()
         {
@@ -101,7 +112,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             abcStream.AbcLoad(createMissingNodes, false);
             forceUpdate = true;
         }
-        
+
         void Start()
         {
             OnValidate();
@@ -119,10 +130,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             forceUpdate = true;
         }
 
-        /// <summary>
-        /// Update the child game object's data to the CurrentTime.
-        /// </summary>
-        public void Update()
+        internal void Update()
         {
             if (abcStream == null || StreamDescriptor == null)
                 return;

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -110,7 +110,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         [SerializeField]
         bool asyncLoad = true;
-
+        
         float lastUpdateTime;
         bool forceUpdate = false;
         bool updateStarted = false;

--- a/com.unity.formats.alembic/Runtime/Scripts/Timeline/AlembicShotAsset.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Timeline/AlembicShotAsset.cs
@@ -1,36 +1,33 @@
-using System;
-using UnityEngine;
 using UnityEngine.Formats.Alembic.Importer;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
 
 namespace UnityEngine.Formats.Alembic.Timeline
 {
+    /// <summary>
+    /// Clip representing the playback range of an Alembic asset
+    /// </summary>
     [System.ComponentModel.DisplayName("Alembic Shot")]
-    internal class AlembicShotAsset : PlayableAsset, ITimelineClipAsset, IPropertyPreview
+    public class AlembicShotAsset : PlayableAsset, ITimelineClipAsset, IPropertyPreview
     {
         AlembicStreamPlayer m_stream;
 
         [Tooltip("Alembic asset to play")]
         [SerializeField]
         private ExposedReference<AlembicStreamPlayer> streamPlayer;
+
+        ClipCaps ITimelineClipAsset.clipCaps { get { return ClipCaps.Extrapolation | ClipCaps.Looping | ClipCaps.SpeedMultiplier | ClipCaps.ClipIn;  } }
+        
+        /// <summary>
+        /// The AlembicStreamPlayer to play.
+        /// </summary>
         public ExposedReference<AlembicStreamPlayer> StreamPlayer
         {
             get { return streamPlayer; }
             set { streamPlayer = value; }
         }
 
-        [Tooltip("Amount of time to clip off the end of the alembic asset from playback.")]
-        [SerializeField]
-        private float endOffset;
-        public float EndOffset
-        {
-            get { return endOffset; }
-            set { endOffset = value; }
-        }
-
-        public ClipCaps clipCaps { get { return ClipCaps.Extrapolation | ClipCaps.Looping | ClipCaps.SpeedMultiplier | ClipCaps.ClipIn;  } }
-
+        /// <inheritdoc/>
         public override Playable CreatePlayable(PlayableGraph graph, GameObject owner)
         {
             var playable = ScriptPlayable<AlembicShotPlayable>.Create(graph);
@@ -40,6 +37,7 @@ namespace UnityEngine.Formats.Alembic.Timeline
             return playable;
         }
 
+        /// <inheritdoc/>
         public override double duration
         {
             get
@@ -48,6 +46,7 @@ namespace UnityEngine.Formats.Alembic.Timeline
             }
         }
 
+        /// <inheritdoc/>
         public void GatherProperties(PlayableDirector director, IPropertyCollector driver)
         {
             var streamComponent = streamPlayer.Resolve(director);

--- a/com.unity.formats.alembic/Runtime/Scripts/Timeline/AlembicShotAsset.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Timeline/AlembicShotAsset.cs
@@ -44,7 +44,7 @@ namespace UnityEngine.Formats.Alembic.Timeline
         {
             get
             {
-                return m_stream == null ? 0 : m_stream.duration;
+                return m_stream == null ? 0 : m_stream.Duration;
             }
         }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Timeline/AlembicShotPlayable.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Timeline/AlembicShotPlayable.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.Formats.Alembic.Timeline
             if (streamPlayer == null)
                 return;
 
-            var duration = streamPlayer.duration;
+            var duration = streamPlayer.Duration;
             var time = playable.GetTime();
             streamPlayer.CurrentTime = (float)(time == duration ? duration : time % duration);
             streamPlayer.Update();

--- a/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
@@ -36,12 +36,12 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         protected IEnumerator RecordAlembic()
         {
             exporter.BeginRecording();
-            while (!exporter.recorder.recording)
+            while (!exporter.Recorder.Recording)
             {
                 yield return null;
             }
 
-            while (exporter.recorder.recording)
+            while (exporter.Recorder.Recording)
             {
                 yield return null;
             }
@@ -54,10 +54,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             SceneManager.SetActiveScene(scene);
             var go = new GameObject("Recorder");
             exporter = go.AddComponent<AlembicExporter>();
-            exporter.maxCaptureFrame = 10;
-            exporter.recorder.settings.OutputPath =
+            exporter.MaxCaptureFrame = 10;
+            exporter.Recorder.Settings.OutputPath =
                 "Assets/" + Path.GetFileNameWithoutExtension(Path.GetTempFileName()) + ".abc";
-            exporter.captureOnStart = false;
+            exporter.CaptureOnStart = false;
 
             var cam = new GameObject("Cam");
             cam.AddComponent<Camera>();

--- a/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
@@ -28,7 +28,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             Assert.That(go, Is.Not.Null);
 
             var player = go.GetComponent<AlembicStreamPlayer>();
-            Assert.GreaterOrEqual(player.duration, minDuration); // More than empty
+            Assert.GreaterOrEqual(player.Duration, minDuration); // More than empty
 
             return go;
         }

--- a/com.unity.formats.alembic/Tests/Runtime/CameraPhysicalParamsTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/CameraPhysicalParamsTests.cs
@@ -77,13 +77,13 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         [UnityTest]
         public IEnumerator TestPhysicalCamParams()
         {
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             exporter.OneShot();
             yield return null;
 
             AssetDatabase.Refresh();
-            Assert.That(File.Exists(exporter.recorder.settings.OutputPath));
-            var abc = AssetDatabase.LoadMainAssetAtPath(exporter.recorder.settings.OutputPath) as GameObject;
+            Assert.That(File.Exists(exporter.Recorder.Settings.OutputPath));
+            var abc = AssetDatabase.LoadMainAssetAtPath(exporter.Recorder.Settings.OutputPath) as GameObject;
             var importedParams = new CamParams();
             importedParams.FromCamera(abc.GetComponentInChildren<Camera>());
             Assert.IsTrue(camParams.Equals(importedParams));

--- a/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
@@ -17,7 +17,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             player.CurrentTime = 0;
             yield return new WaitForEndOfFrame();
             var t0 = meshFiler.sharedMesh.vertices[0];
-            player.CurrentTime = (float)player.duration;
+            player.CurrentTime = (float)player.Duration;
             yield return new WaitForEndOfFrame();
             var t1 = meshFiler.sharedMesh.vertices[0];
             Assert.AreNotEqual(t0, t1);

--- a/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
@@ -38,8 +38,8 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestDefaultExportParams()
         {
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestPlaneContents(go);
         }
     }

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -76,7 +76,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestTimeSampling([Values(TimeSamplingType.Acyclic, TimeSamplingType.Uniform)] int sampleType)
         {
             director.Play();
-            exporter.Recorder.Settings.exportOptions.TimeSamplingType = (TimeSamplingType)sampleType;
+            exporter.Recorder.Settings.ExportOptions.TimeSamplingType = (TimeSamplingType)sampleType;
             yield return RecordAlembic();
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
@@ -87,7 +87,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestXForm([Values(TransformType.Matrix, TransformType.TRS)] int xFormType)
         {
             director.Play();
-            exporter.Recorder.Settings.exportOptions.TranformType = (TransformType)xFormType;
+            exporter.Recorder.Settings.ExportOptions.TranformType = (TransformType)xFormType;
             yield return RecordAlembic();
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
@@ -95,10 +95,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         }
 
         [UnityTest, UnityPlatform(exclude = new[]{RuntimePlatform.LinuxEditor})]
-        public IEnumerator TestArchiveType([Values(aeArchiveType.Ogawa, aeArchiveType.HDF5)] int archiveType)
+        public IEnumerator TestArchiveType([Values(ArchiveType.Ogawa, ArchiveType.HDF5)] int archiveType)
         {
             director.Play();
-            exporter.Recorder.Settings.exportOptions.ArchiveType = (ArchiveType)archiveType;
+            exporter.Recorder.Settings.ExportOptions.ArchiveType = (ArchiveType)archiveType;
             yield return RecordAlembic();
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
@@ -109,7 +109,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestSwapHandedness([Values(true, false)] bool swap)
         {
             director.Play();
-            exporter.Recorder.Settings.exportOptions.SwapHandedness = swap;
+            exporter.Recorder.Settings.ExportOptions.SwapHandedness = swap;
             yield return RecordAlembic();
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
@@ -120,7 +120,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestSwapFaces([Values(true, false)] bool swap)
         {
             director.Play();
-            exporter.Recorder.Settings.exportOptions.SwapFaces = swap;
+            exporter.Recorder.Settings.ExportOptions.SwapFaces = swap;
             yield return RecordAlembic();
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
@@ -131,7 +131,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestScaleFactor()
         {
             director.Play();
-            exporter.Recorder.Settings.exportOptions.ScaleFactor = 1;
+            exporter.Recorder.Settings.ExportOptions.ScaleFactor = 1;
             yield return RecordAlembic();
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
@@ -142,7 +142,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestFrameRate([Values(12, 120)] float frameRate)
         {
             director.Play();
-            exporter.Recorder.Settings.exportOptions.FrameRate = frameRate;
+            exporter.Recorder.Settings.ExportOptions.FrameRate = frameRate;
             exporter.MaxCaptureFrame = 30;
             yield return RecordAlembic();
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -160,10 +160,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             var go = TestAbcImported(exporter.recorder.settings.OutputPath);
             //yield return TestCubeContents(go);
             var player = go.GetComponentInChildren<AlembicStreamPlayer>();
-            player.StartTime = (float)player.StreamDescriptor.abcStartTime-1;
-            Assert.AreEqual(player.StartTime,(float)player.StreamDescriptor.abcStartTime);
-            player.EndTime = (float)player.StreamDescriptor.abcEndTime + 1;
-            Assert.AreEqual(player.EndTime,(float)player.StreamDescriptor.abcEndTime);
+            player.StartTime = player.StreamDescriptor.mediaStartTime-1;
+            Assert.AreEqual(player.StartTime,player.StreamDescriptor.mediaStartTime);
+            player.EndTime = (float)player.StreamDescriptor.mediaEndTime + 1;
+            Assert.AreEqual(player.EndTime,(float)player.StreamDescriptor.mediaEndTime);
             player.CurrentTime = (player.StartTime + player.EndTime) / 2;
             Assert.AreEqual(player.CurrentTime, (player.StartTime + player.EndTime) / 2);
             player.CurrentTime = player.EndTime + 1;

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -147,5 +147,26 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             var go = TestAbcImported(exporter.recorder.settings.OutputPath);
             yield return TestCubeContents(go);
         }
+        
+        [UnityTest]
+        public IEnumerator  TestAlembicStreamPlayerTimeFieldsClampToValidRange()
+        {
+            director.Play();
+            exporter.recorder.settings.Scope = ExportScope.TargetBranch;
+            exporter.recorder.settings.TargetBranch = cube;
+            yield return RecordAlembic();
+            deleteFileList.Add(exporter.recorder.settings.OutputPath);
+            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            //yield return TestCubeContents(go);
+            var player = go.GetComponentInChildren<AlembicStreamPlayer>();
+            player.StartTime = (float)player.StreamDescriptor.abcStartTime-1;
+            Assert.AreEqual(player.StartTime,(float)player.StreamDescriptor.abcStartTime);
+            player.EndTime = (float)player.StreamDescriptor.abcEndTime + 1;
+            Assert.AreEqual(player.EndTime,(float)player.StreamDescriptor.abcEndTime);
+            player.CurrentTime = (player.StartTime + player.EndTime) / 2;
+            Assert.AreEqual(player.CurrentTime, (player.StartTime + player.EndTime) / 2);
+            player.CurrentTime = player.EndTime + 1;
+            Assert.AreEqual(player.CurrentTime, player.EndTime);
+        }
     }
 }

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -54,11 +54,11 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator  TestTargetBranchExport()
         {
             director.Play();
-            exporter.recorder.settings.Scope = ExportScope.TargetBranch;
-            exporter.recorder.settings.TargetBranch = cube;
+            exporter.Recorder.Settings.Scope = ExportScope.TargetBranch;
+            exporter.Recorder.Settings.TargetBranch = cube;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestCubeContents(go);
         }
 
@@ -66,31 +66,31 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator  TestOneShotExport()
         {
             director.Play();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             exporter.OneShot();
             yield return null;
-            TestAbcImported(exporter.recorder.settings.OutputPath, 0);
+            TestAbcImported(exporter.Recorder.Settings.OutputPath, 0);
         }
 
         [UnityTest]
-        public IEnumerator TestTimeSampling([Values(aeTimeSamplingType.Acyclic, aeTimeSamplingType.Uniform)] int sampleType)
+        public IEnumerator TestTimeSampling([Values(TimeSamplingType.Acyclic, TimeSamplingType.Uniform)] int sampleType)
         {
             director.Play();
-            exporter.recorder.settings.conf.TimeSamplingType = (aeTimeSamplingType)sampleType;
+            exporter.Recorder.Settings.exportOptions.TimeSamplingType = (TimeSamplingType)sampleType;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestCubeContents(go);
         }
 
         [UnityTest]
-        public IEnumerator TestXForm([Values(aeXformType.Matrix, aeXformType.TRS)] int xFormType)
+        public IEnumerator TestXForm([Values(TransformType.Matrix, TransformType.TRS)] int xFormType)
         {
             director.Play();
-            exporter.recorder.settings.conf.XformType = (aeXformType)xFormType;
+            exporter.Recorder.Settings.exportOptions.TranformType = (TransformType)xFormType;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestCubeContents(go);
         }
 
@@ -98,10 +98,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestArchiveType([Values(aeArchiveType.Ogawa, aeArchiveType.HDF5)] int archiveType)
         {
             director.Play();
-            exporter.recorder.settings.conf.ArchiveType = (aeArchiveType)archiveType;
+            exporter.Recorder.Settings.exportOptions.ArchiveType = (ArchiveType)archiveType;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestCubeContents(go);
         }
 
@@ -109,10 +109,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestSwapHandedness([Values(true, false)] bool swap)
         {
             director.Play();
-            exporter.recorder.settings.conf.SwapHandedness = swap;
+            exporter.Recorder.Settings.exportOptions.SwapHandedness = swap;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestCubeContents(go);
         }
 
@@ -120,10 +120,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestSwapFaces([Values(true, false)] bool swap)
         {
             director.Play();
-            exporter.recorder.settings.conf.SwapFaces = swap;
+            exporter.Recorder.Settings.exportOptions.SwapFaces = swap;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestCubeContents(go);
         }
 
@@ -131,10 +131,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestScaleFactor()
         {
             director.Play();
-            exporter.recorder.settings.conf.ScaleFactor = 1;
+            exporter.Recorder.Settings.exportOptions.ScaleFactor = 1;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestCubeContents(go);
         }
 
@@ -142,11 +142,11 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestFrameRate([Values(12, 120)] float frameRate)
         {
             director.Play();
-            exporter.recorder.settings.conf.FrameRate = frameRate;
-            exporter.maxCaptureFrame = 30;
+            exporter.Recorder.Settings.exportOptions.FrameRate = frameRate;
+            exporter.MaxCaptureFrame = 30;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestCubeContents(go);
         }
 
@@ -155,11 +155,11 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator  TestAlembicStreamPlayerTimeFieldsClampToValidRange()
         {
             director.Play();
-            exporter.recorder.settings.Scope = ExportScope.TargetBranch;
-            exporter.recorder.settings.TargetBranch = cube;
+            exporter.Recorder.Settings.Scope = ExportScope.TargetBranch;
+            exporter.Recorder.Settings.TargetBranch = cube;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             //yield return TestCubeContents(go);
             var player = go.GetComponentInChildren<AlembicStreamPlayer>();
             player.StartTime = player.StreamDescriptor.mediaStartTime-1;
@@ -176,10 +176,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestMultipleUpdatesPerFrame()
         {
             director.Play();
-            exporter.maxCaptureFrame = 30;
+            exporter.MaxCaptureFrame = 30;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var go = TestAbcImported(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             var root = PrefabUtility.InstantiatePrefab(go) as GameObject;
             var player = root.GetComponent<AlembicStreamPlayer>();
 
@@ -206,16 +206,16 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public IEnumerator TestImportlessAlembic()
         {
             director.Play();
-            exporter.maxCaptureFrame = 30;
+            exporter.MaxCaptureFrame = 30;
             yield return RecordAlembic();
-            deleteFileList.Add(exporter.recorder.settings.OutputPath);
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             
             var sceneName = GUID.Generate().ToString();
             var scene = SceneManager.CreateScene(sceneName);
            SceneManager.SetActiveScene(scene);
            var go = new GameObject("abc");
            var player = go.AddComponent<AlembicStreamPlayer>();
-           var ret = player.LoadFromFile(exporter.recorder.settings.OutputPath);
+           var ret = player.LoadFromFile(exporter.Recorder.Settings.OutputPath);
            Assert.IsTrue(ret);
            
            var cubeGO = go.GetComponentInChildren<MeshRenderer>().gameObject;

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -152,7 +152,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 
         // PublicAPI tests
         [UnityTest]
-        public IEnumerator  TestAlembicStreamPlayerTimeFieldsClampToValidRange()
+        public IEnumerator TestAlembicStreamPlayerTimeFieldsClampToValidRange()
         {
             director.Play();
             exporter.Recorder.Settings.Scope = ExportScope.TargetBranch;
@@ -160,14 +160,17 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             yield return RecordAlembic();
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
-            //yield return TestCubeContents(go);
             var player = go.GetComponentInChildren<AlembicStreamPlayer>();
+            
             player.StartTime = player.StreamDescriptor.mediaStartTime-1;
             Assert.AreEqual(player.StartTime,player.StreamDescriptor.mediaStartTime);
+            
             player.EndTime = (float)player.StreamDescriptor.mediaEndTime + 1;
             Assert.AreEqual(player.EndTime,(float)player.StreamDescriptor.mediaEndTime);
+            
             player.CurrentTime = (player.StartTime + player.EndTime) / 2;
             Assert.AreEqual(player.CurrentTime, (player.StartTime + player.EndTime) / 2);
+            
             player.CurrentTime = player.EndTime + 1;
             Assert.AreEqual(player.CurrentTime, player.EndTime);
         }

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -209,7 +209,9 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             exporter.maxCaptureFrame = 30;
             yield return RecordAlembic();
             deleteFileList.Add(exporter.recorder.settings.OutputPath);
-            var scene = SceneManager.CreateScene(GUID.Generate().ToString());
+            
+            var sceneName = GUID.Generate().ToString();
+            var scene = SceneManager.CreateScene(sceneName);
            SceneManager.SetActiveScene(scene);
            var go = new GameObject("abc");
            var player = go.AddComponent<AlembicStreamPlayer>();
@@ -222,6 +224,12 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
            player.UpdateImmediately(player.Duration);
            var t1  = cubeGO.transform.position;
            Assert.AreNotEqual(t0, t1);
+           
+           var asyncOperation = SceneManager.UnloadSceneAsync(sceneName);
+           while (!asyncOperation.isDone)
+           {
+               yield return null;
+           }
         }
     }
 }

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -24,7 +24,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             player.CurrentTime = 0;
             yield return new WaitForEndOfFrame();
             var t0 = cubeGO.transform.position;
-            player.CurrentTime = (float)player.duration;
+            player.CurrentTime = (float)player.Duration;
             yield return new WaitForEndOfFrame();
             var t1  = cubeGO.transform.position;
             Assert.AreNotEqual(t0, t1);

--- a/package.json.in
+++ b/package.json.in
@@ -19,7 +19,6 @@
         "revision": "@PACKAGE_REVISION@",
         "url": "ssh://git@github.com/unity3d-jp/AlembicForUnity.git"
     }, 
-    "unity": "2018.3",
-    "unityRelease": "4f1",
-    "version": "1.0.6"
+    "unity": "2019.2",
+    "version": "2.0.0-preview.1"
 }


### PR DESCRIPTION
This PR introduces a first pass of public API for Alembic.
The main areas of focus:
Alembic Playback:
* Control import settings
* "Importerless" alembic playback: create a new alemicStreamPlayer on a new GameObject and point to an alembic anywhere on the filesystem
* Trigger synchronous update at a particular time for the StreamPlayer

AlembicExport:
* Configure export params (components types, etc)
* trigger and stop recording

Alembic PointCloud:
* enough reading API to be able to write a new render in userland.

Comment to reviewers:
Please look especially for the following issues:
* changed names for serialized fields
* non conforming public API names: eg: public Properties Start with a capital, etc.
